### PR TITLE
feat: use KMS GenerateDataKey for secret generation

### DIFF
--- a/sdk/kms_policy.go
+++ b/sdk/kms_policy.go
@@ -142,7 +142,7 @@ func buildKMSPolicy(ec2RoleARN, pcr0 string) string {
       "Sid": "EnclaveOperations",
       "Effect": "Allow",
       "Principal": {"AWS": %q},
-      "Action": ["kms:Encrypt", "kms:GetKeyPolicy"],
+      "Action": ["kms:Encrypt", "kms:GetKeyPolicy", "kms:GenerateDataKey"],
       "Resource": "*"
     },
     {


### PR DESCRIPTION
Replace local crypto/rand + KMS Encrypt with a single GenerateDataKey call, leveraging KMS hardware RNG. Add kms:GenerateDataKey to the locked key policy since IAM grants are inert after self-locking.

closes #13 