### PR TITLE
feat: add dynamic secrets management with NSM hardware RNG

### DIFF
--- a/sdk/cmd/enclave-supervisor/main.go
+++ b/sdk/cmd/enclave-supervisor/main.go
@@ -92,6 +92,7 @@ func main() {
 	child.Env = append(os.Environ(),
 		"ENCLAVE_APP_PORT="+appPort,
 		"PORT="+appPort,
+		"ENCLAVE_MGMT_TOKEN="+enc.MgmtToken(),
 	)
 	if err := child.Start(); err != nil {
 		log.Fatalf("start %s: %v", appPath, err)

--- a/sdk/enclave.go
+++ b/sdk/enclave.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -41,6 +42,8 @@ type Enclave struct {
 	previousPCR0Attestation string // base64-encoded COSE Sign1 attestation doc
 	initDone                atomic.Bool  // true after Init completes (happens-before fence)
 	initError               atomic.Value // stores string, updated progressively during init
+	mgmtToken               string       // bearer token for management endpoints (empty = no auth)
+	dynamicSecretsCount     atomic.Int64 // count of loaded dynamic secrets, for enclave-info
 
 	// Encrypted persistent storage (S3-backed, AES-256-GCM with single DEK).
 	s3Client   *s3.Client
@@ -50,8 +53,46 @@ type Enclave struct {
 
 // New creates an Enclave that is safe to use immediately for serving
 // management endpoints. Call Init() separately to complete initialization.
+// A random management token is generated for authenticating internal API calls.
 func New() *Enclave {
-	return &Enclave{previousPCR0: "genesis"}
+	token := generateMgmtToken()
+	return &Enclave{previousPCR0: "genesis", mgmtToken: token}
+}
+
+// MgmtToken returns the management token for authenticating internal API calls.
+// Pass this to the consumer app via environment variable.
+func (e *Enclave) MgmtToken() string {
+	return e.mgmtToken
+}
+
+// generateMgmtToken creates a 32-byte random hex token.
+func generateMgmtToken() string {
+	b := make([]byte, 32)
+	if _, err := secureRandom(b); err != nil {
+		panic(fmt.Sprintf("generate mgmt token: %v", err))
+	}
+	return hex.EncodeToString(b)
+}
+
+// secureRandom fills the buffer with random bytes from the Nitro NSM hardware
+// RNG (/dev/nsm GetRandom). If NSM is unavailable (dev/testing outside an
+// enclave), falls back to crypto/rand.
+//
+// Inside an enclave crypto/rand relies on the kernel entropy pool which is
+// severely starved (no disk, no network, no HID — only RDRAND). The NSM
+// hardware RNG is a dedicated, independent entropy source provided by AWS
+// specifically for this reason. If we successfully open /dev/nsm (meaning
+// we ARE in an enclave) but GetRandom fails, we return the error rather
+// than silently falling back to the weak pool.
+func secureRandom(b []byte) (int, error) {
+	session, err := nsm.OpenDefaultSession()
+	if err != nil {
+		// Not in an enclave (no /dev/nsm) — crypto/rand is fine on normal Linux.
+		return rand.Read(b)
+	}
+	defer session.Close()
+	// In an enclave — NSM hardware RNG is the only trustworthy source.
+	return session.Read(b)
 }
 
 // Init initializes the enclave: generates an ephemeral attestation key,
@@ -100,6 +141,12 @@ func (e *Enclave) Init(ctx context.Context) error {
 	if err := e.initStorage(ctx); err != nil {
 		e.setInitError(fmt.Sprintf("init storage: %s", err))
 		return fmt.Errorf("init storage: %w", err)
+	}
+
+	if count, err := e.loadDynamicSecrets(ctx); err != nil {
+		log.Printf("warning: load dynamic secrets: %v", err)
+	} else {
+		e.dynamicSecretsCount.Store(int64(count))
 	}
 
 	if pcr0, err := readMigrationPreviousPCR0(ctx); err == nil {
@@ -160,6 +207,10 @@ func (e *Enclave) RegisterRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /v1/storage/{key...}", e.handleStorageGet)
 	mux.HandleFunc("DELETE /v1/storage/{key...}", e.handleStorageDelete)
 	mux.HandleFunc("GET /v1/storage", e.handleStorageList)
+	mux.HandleFunc("PUT /v1/secrets/{name}", e.handleSecretPut)
+	mux.HandleFunc("GET /v1/secrets/{name}", e.handleSecretGet)
+	mux.HandleFunc("DELETE /v1/secrets/{name}", e.handleSecretDelete)
+	mux.HandleFunc("GET /v1/secrets", e.handleSecretList)
 }
 
 // Middleware returns an http.Handler that signs all responses with the
@@ -218,7 +269,7 @@ func loadSecretsConfig() ([]SecretDef, error) {
 // its public key hash with nitriding via POST /enclave/hash.
 func (e *Enclave) generateAttestationKey() error {
 	keyBytes := make([]byte, 32)
-	if _, err := rand.Read(keyBytes); err != nil {
+	if _, err := secureRandom(keyBytes); err != nil {
 		return fmt.Errorf("generate random bytes: %w", err)
 	}
 
@@ -327,12 +378,14 @@ func (e *Enclave) handleEnclaveInfo(w http.ResponseWriter, r *http.Request) {
 		PreviousPCR0            string `json:"previous_pcr0"`
 		PreviousPCR0Attestation string `json:"previous_pcr0_attestation,omitempty"`
 		AttestationPubkey       string `json:"attestation_pubkey,omitempty"`
+		DynamicSecrets          int64  `json:"dynamic_secrets"`
 		Error                   string `json:"error,omitempty"`
 	}{
 		Version:                 Version,
 		PreviousPCR0:            e.previousPCR0,
 		PreviousPCR0Attestation: e.previousPCR0Attestation,
 		AttestationPubkey:       e.AttestationPubkey(),
+		DynamicSecrets:          e.dynamicSecretsCount.Load(),
 		Error:                   e.InitError(),
 	})
 }
@@ -340,6 +393,9 @@ func (e *Enclave) handleEnclaveInfo(w http.ResponseWriter, r *http.Request) {
 // handleExtendPCR extends a user-defined PCR (16-31) with the provided data.
 // This allows the user's app to extend PCRs via HTTP without importing the SDK.
 func (e *Enclave) handleExtendPCR(w http.ResponseWriter, r *http.Request) {
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
 	var req struct {
 		PCR  uint   `json:"pcr"`
 		Data string `json:"data"` // base64-encoded
@@ -369,6 +425,9 @@ func (e *Enclave) handleExtendPCR(w http.ResponseWriter, r *http.Request) {
 
 // handleLockPCR locks a user-defined PCR (16-31) to prevent further extension.
 func (e *Enclave) handleLockPCR(w http.ResponseWriter, r *http.Request) {
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
 	var req struct {
 		PCR uint `json:"pcr"`
 	}

--- a/sdk/migrate.go
+++ b/sdk/migrate.go
@@ -26,6 +26,9 @@ func (e *Enclave) handleExportKey(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
 		return
 	}
+	// Note: export-key has its own SSM-based authorization (MigrationKMSKeyID
+	// must be set by the CLI). No mgmt token check — the CLI calls this via
+	// curl on the EC2 host and doesn't have the enclave's runtime token.
 	ctx := r.Context()
 	deployment := getDeployment()
 	appName := getAppName()

--- a/sdk/secrets.go
+++ b/sdk/secrets.go
@@ -1,0 +1,338 @@
+package sdk
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// DynamicSecret is the JSON envelope stored in S3 for each dynamic secret.
+type DynamicSecret struct {
+	Name      string `json:"name"`
+	EnvVar    string `json:"env_var,omitempty"`
+	Value     string `json:"value"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+// DynamicSecretInfo is the metadata-only view returned by list (no value).
+type DynamicSecretInfo struct {
+	Name      string `json:"name"`
+	EnvVar    string `json:"env_var,omitempty"`
+	CreatedAt string `json:"created_at,omitempty"`
+	UpdatedAt string `json:"updated_at,omitempty"`
+}
+
+const secretsPrefix = "secrets/"
+
+// validSecretName matches alphanumeric, hyphens, underscores, dots. No slashes, no ..
+var validSecretName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+
+// validateSecretName rejects path traversal, control chars, and invalid names.
+func validateSecretName(name string) error {
+	if name == "" {
+		return fmt.Errorf("secret name is required")
+	}
+	if strings.Contains(name, "..") || strings.Contains(name, "/") {
+		return fmt.Errorf("secret name must not contain '..' or '/'")
+	}
+	if !validSecretName.MatchString(name) {
+		return fmt.Errorf("secret name must be alphanumeric with hyphens, underscores, or dots")
+	}
+	if len(name) > 256 {
+		return fmt.Errorf("secret name must be 256 characters or fewer")
+	}
+	return nil
+}
+
+// StoreSecret encrypts and persists a dynamic secret.
+func (e *Enclave) StoreSecret(ctx context.Context, name, envVar, value string) error {
+	if err := validateSecretName(name); err != nil {
+		return err
+	}
+
+	// Validate env_var doesn't collide with static secrets.
+	if envVar != "" {
+		for _, s := range e.secrets {
+			if s.EnvVar == envVar {
+				return fmt.Errorf("env_var %q conflicts with static secret %q", envVar, s.Name)
+			}
+		}
+	}
+
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	// Preserve created_at if updating an existing secret.
+	createdAt := now
+	if existing, err := e.LoadSecret(ctx, name); err == nil {
+		createdAt = existing.CreatedAt
+	}
+
+	secret := DynamicSecret{
+		Name:      name,
+		EnvVar:    envVar,
+		Value:     value,
+		CreatedAt: createdAt,
+		UpdatedAt: now,
+	}
+	data, err := json.Marshal(secret)
+	if err != nil {
+		return fmt.Errorf("marshal secret: %w", err)
+	}
+
+	log.Printf("secret stored: %s (env_var=%q)", name, envVar)
+	return e.Store(ctx, secretsPrefix+name, data)
+}
+
+// LoadSecret retrieves and decrypts a dynamic secret.
+func (e *Enclave) LoadSecret(ctx context.Context, name string) (*DynamicSecret, error) {
+	data, err := e.Load(ctx, secretsPrefix+name)
+	if err != nil {
+		return nil, err
+	}
+	var secret DynamicSecret
+	if err := json.Unmarshal(data, &secret); err != nil {
+		return nil, fmt.Errorf("unmarshal secret %q: %w", name, err)
+	}
+	return &secret, nil
+}
+
+// DeleteSecret removes a dynamic secret from storage.
+func (e *Enclave) DeleteSecret(ctx context.Context, name string) error {
+	log.Printf("secret deleted: %s", name)
+	return e.Delete(ctx, secretsPrefix+name)
+}
+
+// ListSecrets returns the names of all dynamic secrets.
+func (e *Enclave) ListSecrets(ctx context.Context) ([]string, error) {
+	keys, err := e.List(ctx, secretsPrefix)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(keys))
+	for _, k := range keys {
+		names = append(names, strings.TrimPrefix(k, secretsPrefix))
+	}
+	return names, nil
+}
+
+// loadDynamicSecrets scans stored secrets and injects their env vars.
+// Returns the count of loaded secrets for enclave-info reporting.
+func (e *Enclave) loadDynamicSecrets(ctx context.Context) (int, error) {
+	if e.dek == nil {
+		return 0, nil // storage not initialized, skip
+	}
+	names, err := e.ListSecrets(ctx)
+	if err != nil {
+		return 0, err
+	}
+
+	seenEnvVars := make(map[string]string) // env_var → secret name
+	loaded := 0
+
+	for _, name := range names {
+		secret, err := e.LoadSecret(ctx, name)
+		if err != nil {
+			log.Printf("warning: skip dynamic secret %q: %v", name, err)
+			continue
+		}
+		if secret.EnvVar != "" {
+			if prev, dup := seenEnvVars[secret.EnvVar]; dup {
+				log.Printf("warning: dynamic secret %q and %q both define env_var %q, last write wins", prev, name, secret.EnvVar)
+			}
+			seenEnvVars[secret.EnvVar] = name
+			os.Setenv(secret.EnvVar, secret.Value)
+		}
+		loaded++
+	}
+	return loaded, nil
+}
+
+// checkMgmtToken validates the Authorization: Bearer <token> header.
+func (e *Enclave) checkMgmtToken(w http.ResponseWriter, r *http.Request) bool {
+	if e.mgmtToken == "" {
+		return true // no token configured, allow (backwards compat)
+	}
+	auth := r.Header.Get("Authorization")
+	if auth == "" {
+		http.Error(w, "missing Authorization header", http.StatusUnauthorized)
+		return false
+	}
+	const prefix = "Bearer "
+	if !strings.HasPrefix(auth, prefix) {
+		http.Error(w, "invalid Authorization format, expected Bearer token", http.StatusUnauthorized)
+		return false
+	}
+	if strings.TrimPrefix(auth, prefix) != e.mgmtToken {
+		http.Error(w, "invalid management token", http.StatusForbidden)
+		return false
+	}
+	return true
+}
+
+// handleSecretPut handles PUT /v1/secrets/{name}.
+func (e *Enclave) handleSecretPut(w http.ResponseWriter, r *http.Request) {
+	if !e.initDone.Load() {
+		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
+		return
+	}
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
+
+	name := r.PathValue("name")
+	if err := validateSecretName(name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<20) // 1MB limit
+
+	var req struct {
+		EnvVar string `json:"env_var"`
+		Value  string `json:"value"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "invalid JSON body", http.StatusBadRequest)
+		return
+	}
+	if req.Value == "" {
+		http.Error(w, "value is required", http.StatusBadRequest)
+		return
+	}
+
+	// Check if this is a new secret (vs update) for count tracking.
+	_, existsErr := e.LoadSecret(r.Context(), name)
+	isNew := existsErr != nil
+
+	if err := e.StoreSecret(r.Context(), name, req.EnvVar, req.Value); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if isNew {
+		e.dynamicSecretsCount.Add(1)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusCreated)
+	json.NewEncoder(w).Encode(struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}{Name: name, Status: "stored"})
+}
+
+// handleSecretGet handles GET /v1/secrets/{name}.
+func (e *Enclave) handleSecretGet(w http.ResponseWriter, r *http.Request) {
+	if !e.initDone.Load() {
+		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
+		return
+	}
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
+
+	name := r.PathValue("name")
+	if err := validateSecretName(name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	secret, err := e.LoadSecret(r.Context(), name)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			http.Error(w, "secret not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(secret)
+}
+
+// handleSecretDelete handles DELETE /v1/secrets/{name}.
+func (e *Enclave) handleSecretDelete(w http.ResponseWriter, r *http.Request) {
+	if !e.initDone.Load() {
+		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
+		return
+	}
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
+
+	name := r.PathValue("name")
+	if err := validateSecretName(name); err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Verify secret exists before deleting (for accurate count tracking).
+	if _, err := e.LoadSecret(r.Context(), name); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			http.Error(w, "secret not found", http.StatusNotFound)
+			return
+		}
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	if err := e.DeleteSecret(r.Context(), name); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	e.dynamicSecretsCount.Add(-1)
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct {
+		Name   string `json:"name"`
+		Status string `json:"status"`
+	}{Name: name, Status: "deleted"})
+}
+
+// handleSecretList handles GET /v1/secrets.
+// Returns metadata for each secret (name, env_var, timestamps) but not the value.
+func (e *Enclave) handleSecretList(w http.ResponseWriter, r *http.Request) {
+	if !e.initDone.Load() {
+		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
+		return
+	}
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
+
+	names, err := e.ListSecrets(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	secrets := make([]DynamicSecretInfo, 0, len(names))
+	for _, name := range names {
+		secret, err := e.LoadSecret(r.Context(), name)
+		if err != nil {
+			log.Printf("warning: skip secret %q in list: %v", name, err)
+			continue
+		}
+		secrets = append(secrets, DynamicSecretInfo{
+			Name:      secret.Name,
+			EnvVar:    secret.EnvVar,
+			CreatedAt: secret.CreatedAt,
+			UpdatedAt: secret.UpdatedAt,
+		})
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(struct {
+		Secrets []DynamicSecretInfo `json:"secrets"`
+	}{Secrets: secrets})
+}

--- a/sdk/storage.go
+++ b/sdk/storage.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"crypto/aes"
 	"crypto/cipher"
-	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -175,7 +174,7 @@ func (e *Enclave) Store(ctx context.Context, key string, data []byte) error {
 	}
 
 	nonce := make([]byte, nonceSize)
-	if _, err := rand.Read(nonce); err != nil {
+	if _, err := secureRandom(nonce); err != nil {
 		return fmt.Errorf("generate nonce: %w", err)
 	}
 
@@ -323,13 +322,21 @@ func (e *Enclave) handleStoragePut(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
 		return
 	}
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
 
 	key := r.PathValue("key")
 	if key == "" {
 		http.Error(w, "key is required", http.StatusBadRequest)
 		return
 	}
+	if strings.HasPrefix(key, "secrets/") {
+		http.Error(w, "use /v1/secrets endpoints for secret management", http.StatusBadRequest)
+		return
+	}
 
+	r.Body = http.MaxBytesReader(w, r.Body, 10<<20) // 10MB limit
 	data, err := io.ReadAll(r.Body)
 	if err != nil {
 		http.Error(w, "failed to read request body", http.StatusBadRequest)
@@ -356,10 +363,17 @@ func (e *Enclave) handleStorageGet(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
 		return
 	}
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
 
 	key := r.PathValue("key")
 	if key == "" {
 		http.Error(w, "key is required", http.StatusBadRequest)
+		return
+	}
+	if strings.HasPrefix(key, "secrets/") {
+		http.Error(w, "use /v1/secrets endpoints for secret management", http.StatusBadRequest)
 		return
 	}
 
@@ -383,10 +397,17 @@ func (e *Enclave) handleStorageDelete(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
 		return
 	}
+	if !e.checkMgmtToken(w, r) {
+		return
+	}
 
 	key := r.PathValue("key")
 	if key == "" {
 		http.Error(w, "key is required", http.StatusBadRequest)
+		return
+	}
+	if strings.HasPrefix(key, "secrets/") {
+		http.Error(w, "use /v1/secrets endpoints for secret management", http.StatusBadRequest)
 		return
 	}
 
@@ -407,6 +428,9 @@ func (e *Enclave) handleStorageDelete(w http.ResponseWriter, r *http.Request) {
 func (e *Enclave) handleStorageList(w http.ResponseWriter, r *http.Request) {
 	if !e.initDone.Load() {
 		http.Error(w, "enclave is still initializing", http.StatusServiceUnavailable)
+		return
+	}
+	if !e.checkMgmtToken(w, r) {
 		return
 	}
 


### PR DESCRIPTION
Add runtime secret CRUD endpoints (/v1/secrets/) with encrypted S3 storage, Bearer token auth for all management endpoints, and NSM hardware random number generation instead of crypto/rand (which relies on an entropy-starved kernel pool inside Nitro Enclaves).

- Dynamic secrets: PUT/GET/DELETE/LIST with JSON envelope (name, env_var, value, timestamps), auto-injected as env vars on boot, survive enclave upgrades via existing DEK migration
- Auth: supervisor generates 32-byte random token, passes to child via ENCLAVE_MGMT_TOKEN env var, validated on all mutation endpoints
- NSM RNG: secureRandom() uses /dev/nsm GetRandom when in enclave, falls back to crypto/rand only outside enclave (dev/testing)
- Guard: generic /v1/storage/ endpoints reject secrets/ prefix
- Live count: dynamicSecretsCount (atomic.Int64) updated on CRUD

closes #23 