### PR TITLE
fix: Change test-build Makefile target to reference enclave-cli binary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ install: ## Install the enclave CLI to $GOPATH/bin with SDK hashes baked in
 test: test-build test-run ## Build test EIFs and run integration tests
 
 test-build:  ## Build test EIFs (v1 + v2 for migration with previousPCR0)
-	cd test/app && enclave build --local
+	cd test/app && ../../enclave-cli build --local
 	cp test/app/enclave/artifacts/pcr.json /tmp/pcr-v1.json
 	V1_PCR0=$$(jq -r '.PCR0' test/app/enclave/artifacts/pcr.json) && \
 	sed -i 's/^version: .*/version: 0.0.2/' test/app/enclave/enclave.yaml && \


### PR DESCRIPTION
When trying to test this out locally, the `enclave-cli` binary wasn't referenced correctly in the `test-build` Makefile target. Not sure, but this new path looks right to me. What do you think?