### PR TITLE
feat: expose nix_build_inputs / nix_native_build_inputs in app config

### DIFF
--- a/build.go
+++ b/build.go
@@ -33,17 +33,19 @@ type buildConfigJSON struct {
 }
 
 type buildConfigAppJSON struct {
-	Language       string            `json:"language"`
-	NixOwner       string            `json:"nix_owner"`
-	NixRepo        string            `json:"nix_repo"`
-	NixRev         string            `json:"nix_rev"`
-	NixHash        string            `json:"nix_hash"`
-	NixVendorHash  string            `json:"nix_vendor_hash"`
-	NixSubPackages []string          `json:"nix_sub_packages"`
-	NixProjectFile string            `json:"nix_project_file"`
-	NixSubdir      string            `json:"nix_subdir"`
-	BinaryName     string            `json:"binary_name"`
-	Env            map[string]string `json:"env"`
+	Language             string            `json:"language"`
+	NixOwner             string            `json:"nix_owner"`
+	NixRepo              string            `json:"nix_repo"`
+	NixRev               string            `json:"nix_rev"`
+	NixHash              string            `json:"nix_hash"`
+	NixVendorHash        string            `json:"nix_vendor_hash"`
+	NixSubPackages       []string          `json:"nix_sub_packages"`
+	NixProjectFile       string            `json:"nix_project_file"`
+	NixSubdir            string            `json:"nix_subdir"`
+	NixBuildInputs       []string          `json:"nix_build_inputs"`
+	NixNativeBuildInputs []string          `json:"nix_native_build_inputs"`
+	BinaryName           string            `json:"binary_name"`
+	Env                  map[string]string `json:"env"`
 }
 
 type buildConfigSecretJSON struct {
@@ -135,6 +137,16 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// nonNilStrings returns an empty slice when xs is nil so JSON marshalling
+// emits "[]" instead of "null". Nix's builtins.fromJSON would otherwise
+// decode a missing/null field to null, breaking list operations downstream.
+func nonNilStrings(xs []string) []string {
+	if xs == nil {
+		return []string{}
+	}
+	return xs
+}
+
 // generateBuildConfig writes build-config.json from enclave.yaml config.
 // Template variables in env values ({{region}}, {{prefix}}, {{version}}) are substituted.
 func generateBuildConfig(cfg *Config, root string) error {
@@ -162,17 +174,19 @@ func generateBuildConfig(cfg *Config, root string) error {
 		Region:  cfg.Region,
 		Prefix:  cfg.Prefix,
 		App: buildConfigAppJSON{
-			Language:       cfg.App.Language,
-			NixOwner:       cfg.App.NixOwner,
-			NixRepo:        cfg.App.NixRepo,
-			NixRev:         cfg.App.NixRev,
-			NixHash:        cfg.App.NixHash,
-			NixVendorHash:  cfg.App.NixVendorHash,
-			NixSubPackages: cfg.App.NixSubPackages,
-			NixProjectFile: cfg.App.NixProjectFile,
-			NixSubdir:      cfg.App.NixSubdir,
-			BinaryName:     cfg.App.BinaryName,
-			Env:            resolvedEnv,
+			Language:             cfg.App.Language,
+			NixOwner:             cfg.App.NixOwner,
+			NixRepo:              cfg.App.NixRepo,
+			NixRev:               cfg.App.NixRev,
+			NixHash:              cfg.App.NixHash,
+			NixVendorHash:        cfg.App.NixVendorHash,
+			NixSubPackages:       cfg.App.NixSubPackages,
+			NixProjectFile:       cfg.App.NixProjectFile,
+			NixSubdir:            cfg.App.NixSubdir,
+			NixBuildInputs:       nonNilStrings(cfg.App.NixBuildInputs),
+			NixNativeBuildInputs: nonNilStrings(cfg.App.NixNativeBuildInputs),
+			BinaryName:           cfg.App.BinaryName,
+			Env:                  resolvedEnv,
 		},
 		Secrets: secrets,
 		SDK: buildConfigSDKJSON{

--- a/build_test.go
+++ b/build_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -130,5 +132,102 @@ func TestGenerateBuildConfig_EnvTemplateSubstitution(t *testing.T) {
 	}
 	if bc.App.Env["DEPLOY_VERSION"] != "2.0.0" {
 		t.Errorf("{{version}} not resolved: got %q", bc.App.Env["DEPLOY_VERSION"])
+	}
+}
+
+func TestNonNilStrings(t *testing.T) {
+	if got := nonNilStrings(nil); !reflect.DeepEqual(got, []string{}) {
+		t.Errorf("nonNilStrings(nil) = %v, want []", got)
+	}
+	in := []string{"openssl", "protobuf"}
+	if got := nonNilStrings(in); !reflect.DeepEqual(got, in) {
+		t.Errorf("nonNilStrings(%v) = %v, want %v", in, got, in)
+	}
+	if got := nonNilStrings([]string{}); !reflect.DeepEqual(got, []string{}) {
+		t.Errorf("nonNilStrings([]) = %v, want []", got)
+	}
+}
+
+// TestGenerateBuildConfig_BuildInputs verifies that user-supplied
+// nix_build_inputs / nix_native_build_inputs flow through into the
+// generated build-config.json.
+func TestGenerateBuildConfig_BuildInputs(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "enclave"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Name:    "app",
+		Version: "1.0.0",
+		Region:  "us-east-1",
+		App: AppConfig{
+			BinaryName:           "app",
+			NixBuildInputs:       []string{"openssl", "zlib"},
+			NixNativeBuildInputs: []string{"pkg-config", "protobuf"},
+		},
+		MigrationCooldown: "0s",
+		PreviousPCR0:      "genesis",
+	}
+
+	if err := generateBuildConfig(cfg, root); err != nil {
+		t.Fatalf("generateBuildConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "enclave", "build-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var bc buildConfigJSON
+	if err := json.Unmarshal(data, &bc); err != nil {
+		t.Fatal(err)
+	}
+
+	if !reflect.DeepEqual(bc.App.NixBuildInputs, []string{"openssl", "zlib"}) {
+		t.Errorf("NixBuildInputs = %v, want [openssl zlib]", bc.App.NixBuildInputs)
+	}
+	if !reflect.DeepEqual(bc.App.NixNativeBuildInputs, []string{"pkg-config", "protobuf"}) {
+		t.Errorf("NixNativeBuildInputs = %v, want [pkg-config protobuf]", bc.App.NixNativeBuildInputs)
+	}
+}
+
+// TestGenerateBuildConfig_BuildInputsNeverNull ensures that when the user
+// omits the two fields in enclave.yaml (so the slices are nil in Go),
+// the generated JSON contains empty arrays rather than null. The flake's
+// resolveInputs helper expects a list, not null.
+func TestGenerateBuildConfig_BuildInputsNeverNull(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "enclave"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &Config{
+		Name:              "app",
+		Version:           "1.0.0",
+		Region:            "us-east-1",
+		App:               AppConfig{BinaryName: "app"}, // NixBuildInputs: nil, NixNativeBuildInputs: nil
+		MigrationCooldown: "0s",
+		PreviousPCR0:      "genesis",
+	}
+
+	if err := generateBuildConfig(cfg, root); err != nil {
+		t.Fatalf("generateBuildConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(root, "enclave", "build-config.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	raw := string(data)
+	if !strings.Contains(raw, `"nix_build_inputs": []`) {
+		t.Errorf("expected empty array for nix_build_inputs, got JSON:\n%s", raw)
+	}
+	if !strings.Contains(raw, `"nix_native_build_inputs": []`) {
+		t.Errorf("expected empty array for nix_native_build_inputs, got JSON:\n%s", raw)
+	}
+	if strings.Contains(raw, `"nix_build_inputs": null`) || strings.Contains(raw, `"nix_native_build_inputs": null`) {
+		t.Errorf("JSON must not emit null for build-input lists, got:\n%s", raw)
 	}
 }

--- a/config.go
+++ b/config.go
@@ -44,11 +44,13 @@ type AppConfig struct {
 	NixRev         string            `yaml:"nix_rev"`
 	NixHash        string            `yaml:"nix_hash"`
 	NixVendorHash  string            `yaml:"nix_vendor_hash"`
-	NixSubPackages []string          `yaml:"nix_sub_packages"`
-	NixProjectFile string            `yaml:"nix_project_file"`
-	NixSubdir      string            `yaml:"nix_subdir"`
-	BinaryName     string            `yaml:"binary_name"`
-	Env            map[string]string `yaml:"env"`
+	NixSubPackages       []string          `yaml:"nix_sub_packages"`
+	NixProjectFile       string            `yaml:"nix_project_file"`
+	NixSubdir            string            `yaml:"nix_subdir"`
+	NixBuildInputs       []string          `yaml:"nix_build_inputs"`
+	NixNativeBuildInputs []string          `yaml:"nix_native_build_inputs"`
+	BinaryName           string            `yaml:"binary_name"`
+	Env                  map[string]string `yaml:"env"`
 }
 
 // SecretConfig defines a secret managed by KMS inside the enclave.

--- a/config_test.go
+++ b/config_test.go
@@ -79,6 +79,60 @@ sdk:
 	}
 }
 
+func TestLoadConfig_BuildInputs(t *testing.T) {
+	writeConfig(t, `
+name: myapp
+region: us-east-1
+app:
+  language: rust
+  nix_build_inputs:
+    - openssl
+    - zlib
+  nix_native_build_inputs:
+    - pkg-config
+    - protobuf
+`)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if got, want := cfg.App.NixBuildInputs, []string{"openssl", "zlib"}; !equalStrings(got, want) {
+		t.Errorf("NixBuildInputs = %v, want %v", got, want)
+	}
+	if got, want := cfg.App.NixNativeBuildInputs, []string{"pkg-config", "protobuf"}; !equalStrings(got, want) {
+		t.Errorf("NixNativeBuildInputs = %v, want %v", got, want)
+	}
+}
+
+func TestLoadConfig_BuildInputsOmitted(t *testing.T) {
+	writeConfig(t, `
+name: myapp
+region: us-east-1
+`)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.App.NixBuildInputs != nil {
+		t.Errorf("NixBuildInputs = %v, want nil when omitted", cfg.App.NixBuildInputs)
+	}
+	if cfg.App.NixNativeBuildInputs != nil {
+		t.Errorf("NixNativeBuildInputs = %v, want nil when omitted", cfg.App.NixNativeBuildInputs)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
 func TestLoadConfig_Defaults(t *testing.T) {
 	writeConfig(t, `
 name: minimal

--- a/framework_files.go
+++ b/framework_files.go
@@ -579,6 +579,10 @@ const frameworkFlakeNix = `{
         region = buildCfg.region;
         deployment = buildCfg.prefix;
 
+        # Resolve user-supplied package names from enclave.yaml
+        # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
+        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+
         # Enclave supervisor — built from the SDK repo.
         # Handles attestation, secrets, PCR extension, reverse proxy with
         # signing middleware. The user's app is just a plain HTTP server.
@@ -625,6 +629,9 @@ const frameworkFlakeNix = `{
           buildFlags = [ "-trimpath" ];
           tags = [ "netgo" ];
           doCheck = false;
+
+          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
 
           postInstall = ''
             # Rename whatever was built to the configured binary name.
@@ -755,6 +762,9 @@ const frameworkFlakeNix = `{
           subPackages = appCfg.nix_sub_packages;
           env.CGO_ENABLED = "0";
           doCheck = false;
+
+          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
         } // (if (appCfg.nix_subdir or "") != "" then {
           sourceRoot = "source/` + "${appCfg.nix_subdir}" + `";
         } else {}));
@@ -802,6 +812,10 @@ const frameworkFlakeNixNodejs = `{
         region = buildCfg.region;
         deployment = buildCfg.prefix;
 
+        # Resolve user-supplied package names from enclave.yaml
+        # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
+        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+
         # Enclave supervisor — built from the SDK repo.
         # Handles attestation, secrets, PCR extension, reverse proxy with
         # signing middleware. The user's app is just a plain HTTP server.
@@ -846,6 +860,9 @@ const frameworkFlakeNixNodejs = `{
           npmDepsHash = if appCfg.nix_vendor_hash == "" then null else appCfg.nix_vendor_hash;
           dontNpmBuild = true;
           doCheck = false;
+
+          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
         } // (if (appCfg.nix_subdir or "") != "" then {
           sourceRoot = "source/` + "${appCfg.nix_subdir}" + `";
         } else {}));
@@ -980,6 +997,9 @@ LAUNCHER
           npmDepsHash = "";
           dontNpmBuild = true;
           doCheck = false;
+
+          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
         } // (if (appCfg.nix_subdir or "") != "" then {
           sourceRoot = "source/` + "${appCfg.nix_subdir}" + `";
         } else {}));
@@ -1339,6 +1359,10 @@ const frameworkFlakeNixDotnet = `{
         region = buildCfg.region;
         deployment = buildCfg.prefix;
 
+        # Resolve user-supplied package names from enclave.yaml
+        # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
+        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+
         # Enclave supervisor — built from the SDK repo.
         enclave-supervisor = eifPkgs.buildGoModule {
           pname = "enclave-supervisor";
@@ -1392,6 +1416,9 @@ const frameworkFlakeNixDotnet = `{
           dotnetPublishFlags = [ "/p:PublishAot=true" "/p:StripSymbols=true" ];
 
           doCheck = false;
+
+          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
         } // (if (appCfg.nix_subdir or "") != "" then {
           sourceRoot = "source/` + "${appCfg.nix_subdir}" + `";
         } else {}));
@@ -1553,6 +1580,10 @@ const frameworkFlakeNixRust = `{
         region = buildCfg.region;
         deployment = buildCfg.prefix;
 
+        # Resolve user-supplied package names from enclave.yaml
+        # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
+        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+
         # Enclave supervisor — built from the SDK repo.
         enclave-supervisor = eifPkgs.buildGoModule {
           pname = "enclave-supervisor";
@@ -1592,6 +1623,9 @@ const frameworkFlakeNixRust = `{
           cargoHash = if appCfg.nix_vendor_hash == "" then "" else appCfg.nix_vendor_hash;
 
           doCheck = false;
+
+          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
 
           postInstall = ''
             # Rename whatever was built to the configured binary name.
@@ -1713,6 +1747,9 @@ const frameworkFlakeNixRust = `{
           };
           cargoHash = "";
           doCheck = false;
+
+          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
         } // (if (appCfg.nix_subdir or "") != "" then {
           sourceRoot = "source";
           cargoRoot = appCfg.nix_subdir;

--- a/framework_files.go
+++ b/framework_files.go
@@ -581,7 +581,7 @@ const frameworkFlakeNix = `{
 
         # Resolve user-supplied package names from enclave.yaml
         # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
-        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+        resolveInputs = names: map (n: eifPkgs.${n}) names;
 
         # Enclave supervisor — built from the SDK repo.
         # Handles attestation, secrets, PCR extension, reverse proxy with
@@ -814,7 +814,7 @@ const frameworkFlakeNixNodejs = `{
 
         # Resolve user-supplied package names from enclave.yaml
         # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
-        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+        resolveInputs = names: map (n: eifPkgs.${n}) names;
 
         # Enclave supervisor — built from the SDK repo.
         # Handles attestation, secrets, PCR extension, reverse proxy with
@@ -1361,7 +1361,7 @@ const frameworkFlakeNixDotnet = `{
 
         # Resolve user-supplied package names from enclave.yaml
         # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
-        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+        resolveInputs = names: map (n: eifPkgs.${n}) names;
 
         # Enclave supervisor — built from the SDK repo.
         enclave-supervisor = eifPkgs.buildGoModule {
@@ -1582,7 +1582,7 @@ const frameworkFlakeNixRust = `{
 
         # Resolve user-supplied package names from enclave.yaml
         # (nix_build_inputs / nix_native_build_inputs) against nixpkgs.
-        resolveInputs = names: map (n: eifPkgs.${n}) (names or []);
+        resolveInputs = names: map (n: eifPkgs.${n}) names;
 
         # Enclave supervisor — built from the SDK repo.
         enclave-supervisor = eifPkgs.buildGoModule {

--- a/setup.go
+++ b/setup.go
@@ -291,9 +291,22 @@ func computeNixHash(root string, rev string) (string, error) {
 	}
 	defer func() { _ = os.RemoveAll(tmpDir) }()
 
+	// Resolve the git top-level. In a monorepo, `root` (where enclave.yaml
+	// lives) can be a subdirectory of the git repo, and `git archive <rev>`
+	// run from a subdirectory archives only that subtree — producing a hash
+	// that never matches fetchFromGitHub, which always fetches the full-repo
+	// tarball from GitHub.
+	topCmd := exec.Command("git", "rev-parse", "--show-toplevel")
+	topCmd.Dir = root
+	topOut, err := topCmd.Output()
+	if err != nil {
+		return "", fmt.Errorf("git rev-parse --show-toplevel: %w", err)
+	}
+	gitTop := strings.TrimSpace(string(topOut))
+
 	// git archive --format=tar.gz --prefix=source/ <rev> | tar xz -C tmpDir
 	archiveCmd := exec.Command("git", "archive", "--format=tar.gz", "--prefix=source/", rev)
-	archiveCmd.Dir = root
+	archiveCmd.Dir = gitTop
 
 	tarCmd := exec.Command("tar", "xz", "-C", tmpDir)
 	tarCmd.Stdin, err = archiveCmd.StdoutPipe()

--- a/setup_test.go
+++ b/setup_test.go
@@ -1,6 +1,10 @@
 package introspector_enclave
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -123,3 +127,122 @@ func TestReplaceYAMLValue(t *testing.T) {
 	}
 }
 
+// TestComputeNixHash_MonorepoUsesRepoRoot guards against the regression
+// where `git archive` was run with cwd set to the enclave.yaml directory.
+// In a monorepo layout (git root != enclave config dir) that caused
+// `git archive` to archive only the subtree, producing a hash that did
+// not match what fetchFromGitHub computes for the full repo tarball.
+//
+// The fix resolves `git rev-parse --show-toplevel` and uses that as cwd.
+//
+// This test creates a repo with the enclave config in a subdirectory,
+// computes the hash via the function-under-test, and compares it to the
+// hash of the full repo archive. They must match.
+func TestComputeNixHash_MonorepoUsesRepoRoot(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	if _, err := exec.LookPath("nix"); err != nil {
+		t.Skip("nix not available")
+	}
+	if _, err := exec.LookPath("tar"); err != nil {
+		t.Skip("tar not available")
+	}
+
+	repo := t.TempDir()
+
+	// Minimal repo with a top-level file AND a subdirectory containing
+	// enclave.yaml (the monorepo shape that previously triggered the bug).
+	if err := os.WriteFile(filepath.Join(repo, "top.txt"), []byte("repo-root-content\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	sub := filepath.Join(repo, "server", "enclave")
+	if err := os.MkdirAll(sub, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "enclave.yaml"), []byte("name: test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	runIn := func(dir, name string, args ...string) {
+		t.Helper()
+		cmd := exec.Command(name, args...)
+		cmd.Dir = dir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%s %v: %v\n%s", name, args, err, out)
+		}
+	}
+	runIn(repo, "git", "init", "-q")
+	runIn(repo, "git", "-c", "user.email=t@t", "-c", "user.name=T", "add", ".")
+	runIn(repo, "git", "-c", "user.email=t@t", "-c", "user.name=T", "commit", "-q", "-m", "init")
+
+	revOut, err := exec.Command("git", "-C", repo, "rev-parse", "HEAD").Output()
+	if err != nil {
+		t.Fatal(err)
+	}
+	rev := strings.TrimSpace(string(revOut))
+
+	// Simulate the buggy caller: pass the subdirectory (where enclave.yaml
+	// lives) as the "root" argument. The fix should still produce the
+	// full-repo hash by resolving the git top-level internally.
+	got, err := computeNixHash(filepath.Join(repo, "server"), rev)
+	if err != nil {
+		t.Fatalf("computeNixHash: %v", err)
+	}
+
+	// Expected = hash of the full repo via git archive run at the git top.
+	expTmp := t.TempDir()
+	archive := exec.Command("git", "archive", "--format=tar.gz", "--prefix=source/", rev)
+	archive.Dir = repo
+	extract := exec.Command("tar", "xz", "-C", expTmp)
+	extract.Stdin, err = archive.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := extract.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := archive.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := extract.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	wantOut, err := exec.Command("nix", "hash", "path", filepath.Join(expTmp, "source")).Output()
+	if err != nil {
+		t.Fatalf("nix hash path: %v", err)
+	}
+	want := strings.TrimSpace(string(wantOut))
+
+	if got != want {
+		t.Errorf("computeNixHash from subdir = %q, want full-repo hash %q", got, want)
+	}
+
+	// Sanity check: the subtree-only hash must DIFFER from the full-repo hash
+	// (otherwise this test can't detect the regression).
+	subTmp := t.TempDir()
+	subArchive := exec.Command("git", "archive", "--format=tar.gz", "--prefix=source/", rev)
+	subArchive.Dir = filepath.Join(repo, "server")
+	subExtract := exec.Command("tar", "xz", "-C", subTmp)
+	subExtract.Stdin, err = subArchive.StdoutPipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := subExtract.Start(); err != nil {
+		t.Fatal(err)
+	}
+	if err := subArchive.Run(); err != nil {
+		t.Fatal(err)
+	}
+	if err := subExtract.Wait(); err != nil {
+		t.Fatal(err)
+	}
+	subHashOut, err := exec.Command("nix", "hash", "path", filepath.Join(subTmp, "source")).Output()
+	if err != nil {
+		t.Fatalf("nix hash path (subtree): %v", err)
+	}
+	subHash := strings.TrimSpace(string(subHashOut))
+	if subHash == want {
+		t.Fatal("test setup is broken: subtree hash equals full-repo hash, cannot detect regression")
+	}
+}

--- a/template.go
+++ b/template.go
@@ -217,6 +217,11 @@ app:
   nix_subdir: ""                 # Subdirectory for monorepo (e.g. "server")
   binary_name: ""                # Output binary name (defaults to 'name')
 
+  # Extra nixpkgs attrs added to the build sandbox.
+  # Names must match attr paths in nixpkgs (e.g. "openssl", "pkg-config").
+  nix_build_inputs: []           # Link-time libs (e.g. ["openssl", "zlib"])
+  nix_native_build_inputs: []    # Build-time tools (e.g. ["pkg-config", "protobuf"])
+
   # Environment variables baked into the EIF.
   # Template vars: {{region}}, {{prefix}}, {{version}}
   env:
@@ -298,6 +303,11 @@ app:
   nix_vendor_hash: ""            # npm deps hash (required)
   nix_subdir: ""                 # Subdirectory for monorepo (e.g. "server")
   binary_name: ""                # Package name from package.json (defaults to 'name')
+
+  # Extra nixpkgs attrs added to the build sandbox.
+  # Names must match attr paths in nixpkgs (e.g. "python3", "pkg-config").
+  nix_build_inputs: []           # Link-time libs (e.g. ["openssl", "cairo"])
+  nix_native_build_inputs: []    # Build-time tools (e.g. ["python3", "pkg-config"])
 
   # Environment variables baked into the EIF.
   # Template vars: {{region}}, {{prefix}}, {{version}}
@@ -583,6 +593,11 @@ app:
   nix_subdir: ""                 # Subdirectory for monorepo (e.g. "server")
   binary_name: ""                # Output binary name (defaults to 'name')
 
+  # Extra nixpkgs attrs added to the build sandbox.
+  # Names must match attr paths in nixpkgs (e.g. "icu", "openssl").
+  nix_build_inputs: []           # Link-time libs (e.g. ["icu", "openssl"])
+  nix_native_build_inputs: []    # Build-time tools
+
   # Environment variables baked into the EIF.
   # Template vars: {{region}}, {{prefix}}, {{version}}
   env:
@@ -778,6 +793,11 @@ app:
   nix_vendor_hash: ""            # Cargo.lock hash (required)
   nix_subdir: ""                 # Subdirectory for monorepo (e.g. "server")
   binary_name: ""                # Output binary name (defaults to 'name')
+
+  # Extra nixpkgs attrs added to the build sandbox.
+  # Names must match attr paths in nixpkgs (e.g. "openssl", "protobuf").
+  nix_build_inputs: []           # Link-time libs (e.g. ["openssl", "zlib"])
+  nix_native_build_inputs: []    # Build-time tools (e.g. ["pkg-config", "protobuf"])
 
   env:
     # MY_APP_DATA_DIR: /app/data

--- a/template_test.go
+++ b/template_test.go
@@ -174,3 +174,63 @@ func TestRunGenerateTemplateGolang(t *testing.T) {
 		t.Error("enclave.yaml should have language: go")
 	}
 }
+
+// TestFlakeTemplatesHaveBuildInputsPlumbing asserts that every language
+// flake template exposes nix_build_inputs / nix_native_build_inputs via
+// a resolveInputs helper and wires them into the upstream-app derivation.
+// Without this, user-supplied build inputs in enclave.yaml would be
+// silently ignored and builds that need native deps (openssl, protoc,
+// cairo, ...) would fail.
+func TestFlakeTemplatesHaveBuildInputsPlumbing(t *testing.T) {
+	for _, lang := range []string{"go", "nodejs", "dotnet", "rust"} {
+		t.Run(lang, func(t *testing.T) {
+			files := getFrameworkFiles(lang)
+			var flake string
+			for _, f := range files {
+				if f.RelPath == "flake.nix" {
+					flake = f.Content
+					break
+				}
+			}
+			if flake == "" {
+				t.Fatalf("no flake.nix in %s framework files", lang)
+			}
+
+			wants := []string{
+				"resolveInputs = names:",
+				"nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or [])",
+				"buildInputs = resolveInputs (appCfg.nix_build_inputs or [])",
+			}
+			for _, w := range wants {
+				if !strings.Contains(flake, w) {
+					t.Errorf("%s flake.nix missing: %q", lang, w)
+				}
+			}
+		})
+	}
+}
+
+// TestEnclaveYamlTemplatesDocumentBuildInputs asserts that every scaffolded
+// enclave.yaml exposes the two new fields with a default of [] so users
+// discover them without having to read the docs.
+func TestEnclaveYamlTemplatesDocumentBuildInputs(t *testing.T) {
+	for _, lang := range []string{"go", "nodejs", "dotnet", "rust"} {
+		t.Run(lang, func(t *testing.T) {
+			tmp := t.TempDir()
+			if err := runGenerateTemplate(tmp, lang); err != nil {
+				t.Fatalf("runGenerateTemplate(%s): %v", lang, err)
+			}
+			data, err := os.ReadFile(filepath.Join(tmp, "enclave", "enclave.yaml"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			yaml := string(data)
+			if !strings.Contains(yaml, "nix_build_inputs: []") {
+				t.Errorf("%s enclave.yaml missing nix_build_inputs: []", lang)
+			}
+			if !strings.Contains(yaml, "nix_native_build_inputs: []") {
+				t.Errorf("%s enclave.yaml missing nix_native_build_inputs: []", lang)
+			}
+		})
+	}
+}

--- a/test/app/enclave/tofu/modules/enclave/ec2.tf
+++ b/test/app/enclave/tofu/modules/enclave/ec2.tf
@@ -7,7 +7,7 @@ data "aws_ami" "al2023" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-*-x86_64"]
+    values = ["al2023-ami-2023.*-x86_64"]
   }
 
   filter {

--- a/tofu_files.go
+++ b/tofu_files.go
@@ -1172,7 +1172,7 @@ data "aws_ami" "al2023" {
 
   filter {
     name   = "name"
-    values = ["al2023-ami-*-x86_64"]
+    values = ["al2023-ami-2023.*-x86_64"]
   }
 
   filter {

--- a/update.go
+++ b/update.go
@@ -82,6 +82,25 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	fmt.Printf("[update] nix_hash: %s\n", nixHash)
+
+	// Write nix_rev + nix_hash to enclave.yaml FIRST so the flake's
+	// vendor-hash-check fetches the new source (not the old commit).
+	// Without this, computeVendorHash would vendor the OLD Cargo.lock
+	// and return a stale hash. See setup.go for the mirroring pattern.
+	cfgPath := filepath.Join(root, configFile)
+	{
+		data, err := os.ReadFile(cfgPath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", configFile, err)
+		}
+		content := string(data)
+		content = replaceYAMLValue(content, "nix_rev", rev)
+		content = replaceYAMLValue(content, "nix_hash", nixHash)
+		if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+			return fmt.Errorf("write %s: %w", configFile, err)
+		}
+	}
 
 	if !skipDeps {
 		if language == "dotnet" {
@@ -102,27 +121,21 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Println("[update] Skipping deps hash (--skip-deps)")
 	}
-	fmt.Printf("[update] nix_hash: %s\n", nixHash)
 	if vendorHash != "" && vendorHash != "deps.json" {
 		fmt.Printf("[update] nix_vendor_hash: %s\n", vendorHash)
 	}
 
-	// 3. Update enclave.yaml.
-	cfgPath := filepath.Join(root, configFile)
-	data, err := os.ReadFile(cfgPath)
-	if err != nil {
-		return fmt.Errorf("read %s: %w", configFile, err)
-	}
-
-	content := string(data)
-	content = replaceYAMLValue(content, "nix_rev", rev)
-	content = replaceYAMLValue(content, "nix_hash", nixHash)
+	// Write nix_vendor_hash if it was computed.
 	if vendorHash != "" && language != "dotnet" {
+		data, err := os.ReadFile(cfgPath)
+		if err != nil {
+			return fmt.Errorf("read %s: %w", configFile, err)
+		}
+		content := string(data)
 		content = replaceYAMLValue(content, "nix_vendor_hash", vendorHash)
-	}
-
-	if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
-		return fmt.Errorf("write %s: %w", configFile, err)
+		if err := os.WriteFile(cfgPath, []byte(content), 0644); err != nil {
+			return fmt.Errorf("write %s: %w", configFile, err)
+		}
 	}
 
 	fmt.Println()


### PR DESCRIPTION
…; fix monorepo nix_hash and update ordering

- Add nix_build_inputs / nix_native_build_inputs to AppConfig and build-config.json, wired into upstream-app and vendor-hash-check derivations for all 4 flake templates (go, nodejs, dotnet, rust) via a resolveInputs helper. nonNilStrings ensures empty arrays serialize as [] not null.
- Fix computeNixHash monorepo regression: git archive now runs at git top-level (resolved via git rev-parse --show-toplevel) instead of the enclave config dir, so the hash matches fetchFromGitHub's full-repo tarball.
- Fix enclave update: write nix_rev + nix_hash to enclave.yaml before computing vendor hash so the flake's vendor-hash-check fetches the new source, mirroring the setup.go pattern.
- Tighten AMI filter to al2023-ami-2023.*-x86_64 to exclude non-AL2023 variants.