### PR TITLE
feat: tofu-driven app.env overrides via SSM (no EIF rebuild)

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,40 @@ secrets:
     env_var: APP_SIGNING_KEY
 ```
 
+Values in `app.env` are baked into the EIF as **build-time defaults** —
+each value contributes to PCR0, so changing one forces an EIF rebuild
+and a migration. To change a value at deploy time **without rebuilding
+the EIF**, hand it to tofu via the `env_values` map. Tofu writes each
+key/value to SSM at `/<deployment>/<app>/env/<key>`, and the runtime
+overlays it on top of the baked default at boot. PCR0 stays identical
+across the override — the schema (the set of keys) is attested, the
+values are not.
+
+There are three places to supply `env_values`, in increasing order of
+precedence:
+
+1. **`TF_VAR_env_values` environment variable** — pairs well with
+   `direnv`, secret managers (sops, vault), and CI runners that
+   already inject env vars natively.
+   ```sh
+   export TF_VAR_env_values='{"MY_APP_DATADIR":"/srv/data"}'
+   tofu apply
+   ```
+2. **`*.auto.tfvars.json` file** — tofu auto-loads any file matching
+   this pattern next to the root module. Best for committed
+   per-environment config (`prod.auto.tfvars.json`,
+   `staging.auto.tfvars.json`).
+   ```json
+   { "env_values": { "MY_APP_DATADIR": "/srv/data" } }
+   ```
+3. **`-var` on the command line** — one-off overrides. Highest
+   precedence.
+   ```sh
+   tofu apply -var 'env_values={"MY_APP_DATADIR":"/srv/data"}'
+   ```
+
+
+
 Your app is a plain HTTP server — no SDK imports needed:
 
 **Go:**
@@ -687,7 +721,7 @@ The Docker test runner image (`test/Dockerfile.runner`) builds QEMU 9.2.4, vhost
 | `app.nix_vendor_hash` | Go vendor hash or npm deps hash (SRI) | (auto by `setup`) |
 | `app.nix_sub_packages` | Go sub-packages to build (Go only) | `["."]` |
 | `app.binary_name` | Output binary name | `{name}` |
-| `app.env` | Environment variables baked into EIF | `{}` |
+| `app.env` | Environment variables baked into EIF as defaults (tofu can override per-deploy via `-var env_values={...}`) | `{}` |
 | `secrets[].name` | Secret name (SSM path component) | (required) |
 | `secrets[].env_var` | Env var for decrypted value | (required) |
 

--- a/cli/framework_files.go
+++ b/cli/framework_files.go
@@ -323,6 +323,10 @@ const frameworkFlakeNix = `{
 
         # Secrets config JSON baked into the EIF for runtime discovery.
         secretsCfgJson = builtins.toJSON (buildCfg.secrets or []);
+        # Names of app.env keys, attested via PCR0. Values for these keys
+        # are baked below as defaults; the runtime overlays tofu-supplied
+        # SSM overrides on top at boot (see runtime/env_overrides.go).
+        appEnvKeysJson = builtins.toJSON (builtins.attrNames (appCfg.env or {}));
 
         # Environment variables for the enclave.
         # Standard vars + all app-specific vars from build-config.json.
@@ -339,6 +343,7 @@ const frameworkFlakeNix = `{
           ENCLAVE_MIGRATION_COOLDOWN=` + "${buildCfg.migration_cooldown or \"0s\"}" + `
           ENCLAVE_PREVIOUS_PCR0=` + "${buildCfg.previous_pcr0 or \"genesis\"}" + `
           ENCLAVE_KMS_KEY_LOCKED=` + "${if buildCfg.is_kms_key_locked or false then \"true\" else \"false\"}" + `
+          ENCLAVE_APP_ENV_KEYS=` + "${appEnvKeysJson}" + `
           ENCLAVE_DEPLOYMENT=` + "${deployment}" + `
           ` + "${appEnvLines}" + `
         '';
@@ -518,6 +523,10 @@ LAUNCHER
 
         # Secrets config JSON baked into the EIF for runtime discovery.
         secretsCfgJson = builtins.toJSON (buildCfg.secrets or []);
+        # Names of app.env keys, attested via PCR0. Values for these keys
+        # are baked below as defaults; the runtime overlays tofu-supplied
+        # SSM overrides on top at boot (see runtime/env_overrides.go).
+        appEnvKeysJson = builtins.toJSON (builtins.attrNames (appCfg.env or {}));
 
         # Environment variables for the enclave.
         # Standard vars + all app-specific vars from build-config.json.
@@ -534,6 +543,7 @@ LAUNCHER
           ENCLAVE_MIGRATION_COOLDOWN=` + "${buildCfg.migration_cooldown or \"0s\"}" + `
           ENCLAVE_PREVIOUS_PCR0=` + "${buildCfg.previous_pcr0 or \"genesis\"}" + `
           ENCLAVE_KMS_KEY_LOCKED=` + "${if buildCfg.is_kms_key_locked or false then \"true\" else \"false\"}" + `
+          ENCLAVE_APP_ENV_KEYS=` + "${appEnvKeysJson}" + `
           ENCLAVE_DEPLOYMENT=` + "${deployment}" + `
           ` + "${appEnvLines}" + `
         '';
@@ -1032,6 +1042,10 @@ const frameworkFlakeNixDotnet = `{
 
         # Secrets config JSON baked into the EIF for runtime discovery.
         secretsCfgJson = builtins.toJSON (buildCfg.secrets or []);
+        # Names of app.env keys, attested via PCR0. Values are baked
+        # below as defaults; the runtime overlays tofu-supplied SSM
+        # overrides on top at boot (see runtime/env_overrides.go).
+        appEnvKeysJson = builtins.toJSON (builtins.attrNames (appCfg.env or {}));
 
         # Environment variables for the enclave.
         enclaveEnv = let
@@ -1047,6 +1061,7 @@ const frameworkFlakeNixDotnet = `{
           ENCLAVE_MIGRATION_COOLDOWN=` + "${buildCfg.migration_cooldown or \"0s\"}" + `
           ENCLAVE_PREVIOUS_PCR0=` + "${buildCfg.previous_pcr0 or \"genesis\"}" + `
           ENCLAVE_KMS_KEY_LOCKED=` + "${if buildCfg.is_kms_key_locked or false then \"true\" else \"false\"}" + `
+          ENCLAVE_APP_ENV_KEYS=` + "${appEnvKeysJson}" + `
           ENCLAVE_DEPLOYMENT=` + "${deployment}" + `
           DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false
           ` + "${appEnvLines}" + `
@@ -1191,6 +1206,7 @@ const frameworkFlakeNixRust = `{
         };
 
         secretsCfgJson = builtins.toJSON (buildCfg.secrets or []);
+        appEnvKeysJson = builtins.toJSON (builtins.attrNames (appCfg.env or {}));
 
         enclaveEnv = let
           appEnvLines = builtins.concatStringsSep "\n"
@@ -1205,6 +1221,7 @@ const frameworkFlakeNixRust = `{
           ENCLAVE_MIGRATION_COOLDOWN=` + "${buildCfg.migration_cooldown or \"0s\"}" + `
           ENCLAVE_PREVIOUS_PCR0=` + "${buildCfg.previous_pcr0 or \"genesis\"}" + `
           ENCLAVE_KMS_KEY_LOCKED=` + "${if buildCfg.is_kms_key_locked or false then \"true\" else \"false\"}" + `
+          ENCLAVE_APP_ENV_KEYS=` + "${appEnvKeysJson}" + `
           ENCLAVE_DEPLOYMENT=` + "${deployment}" + `
           ` + "${appEnvLines}" + `
         '';

--- a/cli/init.go
+++ b/cli/init.go
@@ -48,7 +48,11 @@ app:
   binary_name: ""                # Output binary name (defaults to 'name')
   release_tag: "eif-latest"      # GitHub Release tag used by 'enclave tofu --remote'
 
-  # Environment variables baked into the EIF.
+  # Environment variables baked into the EIF as build-time defaults
+  # (each value contributes to PCR0). Tofu can override any key here
+  # at deploy time via -var 'env_values={"MY_KEY":"new-value"}' without
+  # rebuilding the EIF — the runtime overlays the SSM value on top of
+  # the baked default at boot.
   # Template vars: {{region}}, {{prefix}}, {{version}}
   env:
     # MY_APP_DATA_DIR: /app/data

--- a/cli/template.go
+++ b/cli/template.go
@@ -229,7 +229,11 @@ app:
   nix_build_inputs: []           # Link-time libs (e.g. ["openssl", "zlib"])
   nix_native_build_inputs: []    # Build-time tools (e.g. ["pkg-config", "protobuf"])
 
-  # Environment variables baked into the EIF.
+  # Environment variables baked into the EIF as build-time defaults
+  # (each value contributes to PCR0). Tofu can override any key here
+  # at deploy time via -var 'env_values={"MY_KEY":"new-value"}' without
+  # rebuilding the EIF — the runtime overlays the SSM value on top of
+  # the baked default at boot.
   # Template vars: {{region}}, {{prefix}}, {{version}}
   env:
     # MY_APP_DATA_DIR: /app/data
@@ -319,7 +323,11 @@ app:
   nix_build_inputs: []           # Link-time libs (e.g. ["openssl", "cairo"])
   nix_native_build_inputs: []    # Build-time tools (e.g. ["python3", "pkg-config"])
 
-  # Environment variables baked into the EIF.
+  # Environment variables baked into the EIF as build-time defaults
+  # (each value contributes to PCR0). Tofu can override any key here
+  # at deploy time via -var 'env_values={"MY_KEY":"new-value"}' without
+  # rebuilding the EIF — the runtime overlays the SSM value on top of
+  # the baked default at boot.
   # Template vars: {{region}}, {{prefix}}, {{version}}
   env:
     # MY_APP_DATA_DIR: /app/data
@@ -611,7 +619,11 @@ app:
   nix_build_inputs: []           # Link-time libs (e.g. ["icu", "openssl"])
   nix_native_build_inputs: []    # Build-time tools
 
-  # Environment variables baked into the EIF.
+  # Environment variables baked into the EIF as build-time defaults
+  # (each value contributes to PCR0). Tofu can override any key here
+  # at deploy time via -var 'env_values={"MY_KEY":"new-value"}' without
+  # rebuilding the EIF — the runtime overlays the SSM value on top of
+  # the baked default at boot.
   # Template vars: {{region}}, {{prefix}}, {{version}}
   env:
     # MY_APP_DATA_DIR: /app/data

--- a/cli/tofu_files.go
+++ b/cli/tofu_files.go
@@ -53,6 +53,8 @@ module "enclave" {
 
   eif_path               = var.eif_path
   supervisor_binary_path = var.supervisor_binary_path
+
+  env_values = var.env_values
 }
 
 # =============================================================================
@@ -170,6 +172,12 @@ variable "supervisor_binary_path" {
   description = "Local path to supervisor binary. Overrides GitHub Release download."
   type        = string
   default     = ""
+}
+
+variable "env_values" {
+  description = "Deploy-time overrides for keys declared in app.env (enclave.yaml). Each key/value here is written to SSM at /<deployment>/<app>/env/<key>; the runtime overlays them on top of the EIF's baked defaults at boot. Keys not present in app.env are still written but never read."
+  type        = map(string)
+  default     = {}
 }
 
 
@@ -342,6 +350,12 @@ variable "supervisor_binary_path" {
   description = "Local path to supervisor binary. Overrides GitHub Release download."
   type        = string
   default     = ""
+}
+
+variable "env_values" {
+  description = "Deploy-time overrides for keys declared in app.env (enclave.yaml). Each key/value here is written to SSM at /<deployment>/<app>/env/<key>; the runtime overlays them on top of the EIF's baked defaults at boot. Keys not present in app.env are still written but never read."
+  type        = map(string)
+  default     = {}
 }
 
 
@@ -570,9 +584,10 @@ data "aws_iam_policy_document" "enclave" {
   statement {
     sid     = "SSMReadOnly"
     actions = ["ssm:GetParameter"]
-    resources = [
-      aws_ssm_parameter.storage_bucket_name.arn,
-    ]
+    resources = concat(
+      [aws_ssm_parameter.storage_bucket_name.arn],
+      [for p in aws_ssm_parameter.env_override : p.arn],
+    )
   }
 
   # SSM: KMSKeyID needs read+write (supervisor updates it during migration).
@@ -896,6 +911,18 @@ resource "aws_ssm_parameter" "migration_storage_dek" {
   lifecycle {
     ignore_changes = [value]
   }
+}
+
+# Deploy-time app.env overrides. The runtime reads each key listed in
+# ENCLAVE_APP_ENV_KEYS (baked into the EIF) and overlays the SSM value
+# on top of the baked default. Missing keys leave the default in place.
+resource "aws_ssm_parameter" "env_override" {
+  for_each = var.env_values
+
+  name      = "/${var.deployment}/${var.app_name}/env/${each.key}"
+  type      = "String"
+  value     = each.value
+  overwrite = true
 }
 
 # =============================================================================

--- a/runtime/env_overrides.go
+++ b/runtime/env_overrides.go
@@ -1,0 +1,60 @@
+package runtime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+// ssmGetter is the subset of *ssm.Client used by applyEnvOverrides — kept
+// minimal so tests can supply a fake.
+type ssmGetter interface {
+	GetParameter(ctx context.Context, params *ssm.GetParameterInput, optFns ...func(*ssm.Options)) (*ssm.GetParameterOutput, error)
+}
+
+// applyEnvOverrides reads ENCLAVE_APP_ENV_KEYS (a JSON list of app.env keys
+// baked into the EIF and attested via PCR0) and, for each key, fetches the
+// tofu-supplied override from SSM at /<deployment>/<app>/env/<key>. When a
+// param exists, its value replaces the baked default in os.Environ() so the
+// child app inherits the override. Missing params (ParameterNotFound) leave
+// the baked default intact.
+func applyEnvOverrides(ctx context.Context, ssmClient ssmGetter, deployment, appName string) error {
+	raw := os.Getenv("ENCLAVE_APP_ENV_KEYS")
+	if raw == "" || raw == "[]" {
+		return nil
+	}
+	var keys []string
+	if err := json.Unmarshal([]byte(raw), &keys); err != nil {
+		return fmt.Errorf("parse ENCLAVE_APP_ENV_KEYS: %w", err)
+	}
+	for _, key := range keys {
+		paramName := fmt.Sprintf("/%s/%s/env/%s", deployment, appName, key)
+		out, err := ssmClient.GetParameter(ctx, &ssm.GetParameterInput{
+			Name:           aws.String(paramName),
+			WithDecryption: aws.Bool(false),
+		})
+		if err != nil {
+			var pnf *ssmtypes.ParameterNotFound
+			if errors.As(err, &pnf) {
+				continue
+			}
+			return fmt.Errorf("ssm get-parameter %s: %w", paramName, err)
+		}
+		if out.Parameter == nil || out.Parameter.Value == nil {
+			continue
+		}
+		value := *out.Parameter.Value
+		if err := os.Setenv(key, value); err != nil {
+			return fmt.Errorf("setenv %s: %w", key, err)
+		}
+		slog.Info("app.env override applied", "key", key)
+	}
+	return nil
+}

--- a/runtime/env_overrides_test.go
+++ b/runtime/env_overrides_test.go
@@ -1,0 +1,116 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
+	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
+)
+
+type fakeSSM struct {
+	params map[string]string
+	err    error
+	calls  []string
+}
+
+func (f *fakeSSM) GetParameter(_ context.Context, in *ssm.GetParameterInput, _ ...func(*ssm.Options)) (*ssm.GetParameterOutput, error) {
+	name := aws.ToString(in.Name)
+	f.calls = append(f.calls, name)
+	if f.err != nil {
+		return nil, f.err
+	}
+	v, ok := f.params[name]
+	if !ok {
+		return nil, &ssmtypes.ParameterNotFound{}
+	}
+	return &ssm.GetParameterOutput{
+		Parameter: &ssmtypes.Parameter{Name: aws.String(name), Value: aws.String(v)},
+	}, nil
+}
+
+func TestApplyEnvOverrides(t *testing.T) {
+	type tc struct {
+		name      string
+		schema    string
+		baked     map[string]string
+		ssmParams map[string]string
+		ssmErr    error
+		want      map[string]string // expected env value after override
+		wantErr   bool
+	}
+	cases := []tc{
+		{
+			name:      "override applied for matching key",
+			schema:    `["API_URL","ROLLOUT_ID"]`,
+			baked:     map[string]string{"API_URL": "default", "ROLLOUT_ID": "green"},
+			ssmParams: map[string]string{"/dev/myapp/env/API_URL": "https://prod.example.com"},
+			want:      map[string]string{"API_URL": "https://prod.example.com", "ROLLOUT_ID": "green"},
+		},
+		{
+			name:      "missing ssm param leaves baked default",
+			schema:    `["API_URL"]`,
+			baked:     map[string]string{"API_URL": "default"},
+			ssmParams: map[string]string{},
+			want:      map[string]string{"API_URL": "default"},
+		},
+		{
+			name:      "empty schema is a no-op",
+			schema:    `[]`,
+			baked:     map[string]string{"X": "x"},
+			ssmParams: map[string]string{"/dev/myapp/env/X": "override"},
+			want:      map[string]string{"X": "x"},
+		},
+		{
+			name:    "malformed schema returns error",
+			schema:  `not-json`,
+			wantErr: true,
+		},
+		{
+			name:    "ssm error other than NotFound is fatal",
+			schema:  `["X"]`,
+			baked:   map[string]string{"X": "x"},
+			ssmErr:  errors.New("access denied"),
+			wantErr: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Setenv("ENCLAVE_APP_ENV_KEYS", c.schema)
+			for k, v := range c.baked {
+				t.Setenv(k, v)
+			}
+			fake := &fakeSSM{params: c.ssmParams, err: c.ssmErr}
+			err := applyEnvOverrides(context.Background(), fake, "dev", "myapp")
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for k, want := range c.want {
+				if got := os.Getenv(k); got != want {
+					t.Errorf("env[%s] = %q, want %q", k, got, want)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyEnvOverridesEmptyEnvVar(t *testing.T) {
+	t.Setenv("ENCLAVE_APP_ENV_KEYS", "")
+	fake := &fakeSSM{}
+	if err := applyEnvOverrides(context.Background(), fake, "dev", "myapp"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(fake.calls) != 0 {
+		t.Errorf("expected no SSM calls, got %d", len(fake.calls))
+	}
+}

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -272,6 +272,18 @@ func (e *Runtime) Init(ctx context.Context) error {
 	}
 
 	deleteOldKMSKey(ctx)
+
+	// Overlay tofu-supplied app.env overrides on top of the baked defaults.
+	// Must happen before the supervisor spawns the child app (which inherits
+	// os.Environ()).
+	awsCfgEnv, err := loadAWSConfigWithIMDS(ctx)
+	if err != nil {
+		return fmt.Errorf("load aws config for env overrides: %w", err)
+	}
+	if err := applyEnvOverrides(ctx, newSSMClient(awsCfgEnv), getDeployment(), getAppName()); err != nil {
+		return fmt.Errorf("apply env overrides: %w", err)
+	}
+
 	e.initOK.Store(true)
 	slog.Info("init completed successfully")
 	SpanOK(initSpan)

--- a/test/app/cmd/main.go
+++ b/test/app/cmd/main.go
@@ -117,6 +117,7 @@ func main() {
 	mux.HandleFunc("GET /test/attestation-persistence", handleTestAttestationPersistence)
 	mux.HandleFunc("GET /test/attestation-binding", handleTestAttestationBinding)
 	mux.HandleFunc("GET /test/logs", handleTestLogs)
+	mux.HandleFunc("GET /test/env-override", handleTestEnvOverride)
 
 	// Wrap mux with otelhttp — every incoming request creates a span automatically.
 	handler := otelhttp.NewHandler(mux, "test-app",
@@ -1163,4 +1164,16 @@ func handleTestLogs(w http.ResponseWriter, r *http.Request) {
 
 	results["status"] = "ok"
 	json.NewEncoder(w).Encode(results)
+}
+
+// handleTestEnvOverride exposes the TEST_RUNTIME_OVERRIDE* keys so the
+// integration test can assert tofu's deploy-time overrides (supplied via
+// env_values.auto.tfvars.json) flowed through SSM into the child app.
+func handleTestEnvOverride(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]string{
+		"status":                        "ok",
+		"test_runtime_override":         os.Getenv("TEST_RUNTIME_OVERRIDE"),
+		"test_runtime_override_envfile": os.Getenv("TEST_RUNTIME_OVERRIDE_ENVFILE"),
+	})
 }

--- a/test/app/enclave/enclave.yaml
+++ b/test/app/enclave/enclave.yaml
@@ -43,6 +43,9 @@ app:
     AWS_SECRET_ACCESS_KEY: "test"
     ENCLAVE_LOG_CLOUDWATCH: "true"
     AWS_ENDPOINT_URL_LOGS: "http://host.containers.internal:4566"
+    # Baked defaults; tofu overrides both keys via env_values.auto.tfvars.json
+    TEST_RUNTIME_OVERRIDE: "default-from-yaml"
+    TEST_RUNTIME_OVERRIDE_ENVFILE: "default-from-yaml"
 
 # One secret for testing KMS secret init and migration.
 secrets:

--- a/test/app/enclave/flake.nix
+++ b/test/app/enclave/flake.nix
@@ -47,11 +47,11 @@
             builtins.path { path = localPath; name = "source"; }
           else
             eifPkgs.fetchFromGitHub {
-              owner = "ArkLabsHQ";
-              repo = "introspector-enclave";
-              rev = runtimeCfg.rev;
-              hash = runtimeCfg.hash;
-            };
+            owner = "ArkLabsHQ";
+            repo = "introspector-enclave";
+            rev = runtimeCfg.rev;
+            hash = runtimeCfg.hash;
+          };
 
         runtime = eifPkgs.buildGoModule {
           pname = "runtime";
@@ -151,6 +151,10 @@
 
         # Secrets config JSON baked into the EIF for runtime discovery.
         secretsCfgJson = builtins.toJSON (buildCfg.secrets or []);
+        # Names of app.env keys, attested via PCR0. Values for these keys
+        # are baked below as defaults; the runtime overlays tofu-supplied
+        # SSM overrides on top at boot (see runtime/env_overrides.go).
+        appEnvKeysJson = builtins.toJSON (builtins.attrNames (appCfg.env or {}));
 
         # Environment variables for the enclave.
         # Standard vars + all app-specific vars from build-config.json.
@@ -166,6 +170,8 @@
           ENCLAVE_SECRETS_CONFIG=${secretsCfgJson}
           ENCLAVE_MIGRATION_COOLDOWN=${buildCfg.migration_cooldown or "0s"}
           ENCLAVE_PREVIOUS_PCR0=${buildCfg.previous_pcr0 or "genesis"}
+          ENCLAVE_KMS_KEY_LOCKED=${if buildCfg.is_kms_key_locked or false then "true" else "false"}
+          ENCLAVE_APP_ENV_KEYS=${appEnvKeysJson}
           ENCLAVE_DEPLOYMENT=${deployment}
           ${appEnvLines}
         '';

--- a/test/app/tofu/env_values.auto.tfvars.json
+++ b/test/app/tofu/env_values.auto.tfvars.json
@@ -1,0 +1,6 @@
+{
+  "env_values": {
+    "TEST_RUNTIME_OVERRIDE": "override-from-tofu",
+    "TEST_RUNTIME_OVERRIDE_ENVFILE": "override-from-envfile"
+  }
+}

--- a/test/app/tofu/main.tf
+++ b/test/app/tofu/main.tf
@@ -29,24 +29,26 @@ provider "aws" {
 module "enclave" {
   source = "./modules/enclave"
 
-  region             = var.region
-  account            = var.account
-  deployment         = var.deployment
-  app_name           = var.app_name
-  instance_type      = var.instance_type
-  local              = var.local
-  secrets            = var.secrets
+  region            = var.region
+  account           = var.account
+  deployment        = var.deployment
+  app_name          = var.app_name
+  instance_type     = var.instance_type
+  local             = var.local
+  secrets           = var.secrets
   migration_cooldown = var.migration_cooldown
-  previous_pcr0      = var.previous_pcr0
-  expected_pcr0      = var.expected_pcr0
-  supervisor_url     = var.supervisor_url
-  github_owner       = var.github_owner
-  github_repo        = var.github_repo
-  release_tag        = var.release_tag
-  github_token       = var.github_token
+  previous_pcr0     = var.previous_pcr0
+  expected_pcr0     = var.expected_pcr0
+  supervisor_url          = var.supervisor_url
+  github_owner  = var.github_owner
+  github_repo   = var.github_repo
+  release_tag   = var.release_tag
+  github_token  = var.github_token
 
   eif_path               = var.eif_path
   supervisor_binary_path = var.supervisor_binary_path
+
+  env_values = var.env_values
 }
 
 # =============================================================================
@@ -164,6 +166,12 @@ variable "supervisor_binary_path" {
   description = "Local path to supervisor binary. Overrides GitHub Release download."
   type        = string
   default     = ""
+}
+
+variable "env_values" {
+  description = "Deploy-time overrides for keys declared in app.env (enclave.yaml). Each key/value here is written to SSM at /<deployment>/<app>/env/<key>; the runtime overlays them on top of the EIF's baked defaults at boot. Keys not present in app.env are still written but never read."
+  type        = map(string)
+  default     = {}
 }
 
 

--- a/test/app/tofu/modules/enclave/main.tf
+++ b/test/app/tofu/modules/enclave/main.tf
@@ -135,6 +135,12 @@ variable "supervisor_binary_path" {
   default     = ""
 }
 
+variable "env_values" {
+  description = "Deploy-time overrides for keys declared in app.env (enclave.yaml). Each key/value here is written to SSM at /<deployment>/<app>/env/<key>; the runtime overlays them on top of the EIF's baked defaults at boot. Keys not present in app.env are still written but never read."
+  type        = map(string)
+  default     = {}
+}
+
 
 # =============================================================================
 # KMS
@@ -184,31 +190,31 @@ resource "null_resource" "kms_key" {
 
       # Apply initial key policy.
       POLICY='${jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Sid       = "AllowRootAccount"
-        Effect    = "Allow"
-        Principal = { AWS = "arn:aws:iam::${var.account}:root" }
-        Action    = "kms:*"
-        Resource  = "*"
-      },
-      {
-        Sid       = "AllowInstanceRole"
-        Effect    = "Allow"
-        Principal = { AWS = aws_iam_role.instance.arn }
-        Action = [
-          "kms:Encrypt",
-          "kms:Decrypt",
-          "kms:GenerateDataKey",
-          "kms:DescribeKey",
-          "kms:PutKeyPolicy",
-          "kms:GetKeyPolicy",
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Sid       = "AllowRootAccount"
+            Effect    = "Allow"
+            Principal = { AWS = "arn:aws:iam::${var.account}:root" }
+            Action    = "kms:*"
+            Resource  = "*"
+          },
+          {
+            Sid       = "AllowInstanceRole"
+            Effect    = "Allow"
+            Principal = { AWS = aws_iam_role.instance.arn }
+            Action = [
+              "kms:Encrypt",
+              "kms:Decrypt",
+              "kms:GenerateDataKey",
+              "kms:DescribeKey",
+              "kms:PutKeyPolicy",
+              "kms:GetKeyPolicy",
+            ]
+            Resource = "*"
+          },
         ]
-        Resource = "*"
-      },
-    ]
-})}'
+      })}'
 
       aws kms put-key-policy --key-id "$KEY_ID" --policy-name default \
         --policy "$POLICY" --region ${var.region}
@@ -221,13 +227,13 @@ resource "null_resource" "kms_key" {
 
       echo "KMS key $KEY_ID stored in SSM"
     EOT
-}
+  }
 
-# On destroy: schedule the KMS key for deletion and remove the SSM pointer
-# so that a subsequent apply creates a fresh key.
-provisioner "local-exec" {
-  when    = destroy
-  command = <<-EOT
+  # On destroy: schedule the KMS key for deletion and remove the SSM pointer
+  # so that a subsequent apply creates a fresh key.
+  provisioner "local-exec" {
+    when    = destroy
+    command = <<-EOT
       set -e
       REGION="${lookup(self.triggers, "region", "us-east-1")}"
       DEPLOYMENT="${self.triggers.deployment}"
@@ -252,7 +258,7 @@ provisioner "local-exec" {
         echo "No KMS key found in SSM — nothing to clean up"
       fi
     EOT
-}
+  }
 }
 
 # Read the KMS key ID from SSM (written by null_resource.kms_key or supervisor).
@@ -361,9 +367,10 @@ data "aws_iam_policy_document" "enclave" {
   statement {
     sid     = "SSMReadOnly"
     actions = ["ssm:GetParameter"]
-    resources = [
-      aws_ssm_parameter.storage_bucket_name.arn,
-    ]
+    resources = concat(
+      [aws_ssm_parameter.storage_bucket_name.arn],
+      [for p in aws_ssm_parameter.env_override : p.arn],
+    )
   }
 
   # SSM: KMSKeyID needs read+write (supervisor updates it during migration).
@@ -422,9 +429,9 @@ data "aws_iam_policy_document" "enclave" {
 
 locals {
   # When local paths are set, use them directly. Otherwise download from GitHub Release.
-  use_local     = var.eif_path != ""
-  artifacts_dir = "${path.module}/.artifacts"
-  release_base  = "https://github.com/${var.github_owner}/${var.github_repo}/releases/download/${var.release_tag}"
+  use_local      = var.eif_path != ""
+  artifacts_dir  = "${path.module}/.artifacts"
+  release_base   = "https://github.com/${var.github_owner}/${var.github_repo}/releases/download/${var.release_tag}"
 
   eif_source        = local.use_local ? var.eif_path : "${local.artifacts_dir}/image.eif"
   supervisor_source = local.use_local ? var.supervisor_binary_path : "${local.artifacts_dir}/supervisor"
@@ -689,6 +696,18 @@ resource "aws_ssm_parameter" "migration_storage_dek" {
   }
 }
 
+# Deploy-time app.env overrides. The runtime reads each key listed in
+# ENCLAVE_APP_ENV_KEYS (baked into the EIF) and overlays the SSM value
+# on top of the baked default. Missing keys leave the default in place.
+resource "aws_ssm_parameter" "env_override" {
+  for_each = var.env_values
+
+  name      = "/${var.deployment}/${var.app_name}/env/${each.key}"
+  type      = "String"
+  value     = each.value
+  overwrite = true
+}
+
 # =============================================================================
 # VPC
 # =============================================================================
@@ -941,10 +960,10 @@ resource "aws_instance" "nitro" {
   # Wait for IAM policy before booting — user_data downloads from S3 immediately.
   depends_on = [aws_iam_role_policy.enclave]
 
-  ami                    = data.aws_ami.al2023[0].id
-  instance_type          = var.instance_type
-  subnet_id              = aws_subnet.public[0].id
-  iam_instance_profile   = aws_iam_instance_profile.instance.name
+  ami                  = data.aws_ami.al2023[0].id
+  instance_type        = var.instance_type
+  subnet_id            = aws_subnet.public[0].id
+  iam_instance_profile = aws_iam_instance_profile.instance.name
   vpc_security_group_ids = [aws_security_group.nitro[0].id]
 
   enclave_options {
@@ -959,14 +978,14 @@ resource "aws_instance" "nitro" {
   }
 
   user_data = templatefile("${path.module}/templates/user_data.sh.tftpl", {
-    region                   = var.region
-    dev_mode                 = var.deployment
-    app_name                 = var.app_name
-    kms_key_id               = local.kms_key_id
-    eif_s3_url               = "s3://${aws_s3_bucket.assets.id}/${aws_s3_object.enclave_eif.key}"
-    supervisor_binary_s3_url = "s3://${aws_s3_bucket.assets.id}/${aws_s3_object.supervisor_binary.key}"
-    migration_cooldown       = var.migration_cooldown
-    previous_pcr0            = var.previous_pcr0
+    region                    = var.region
+    dev_mode                  = var.deployment
+    app_name                  = var.app_name
+    kms_key_id                = local.kms_key_id
+    eif_s3_url                = "s3://${aws_s3_bucket.assets.id}/${aws_s3_object.enclave_eif.key}"
+    supervisor_binary_s3_url  = "s3://${aws_s3_bucket.assets.id}/${aws_s3_object.supervisor_binary.key}"
+    migration_cooldown        = var.migration_cooldown
+    previous_pcr0             = var.previous_pcr0
   })
 
   tags = {
@@ -982,8 +1001,8 @@ resource "aws_instance" "nitro" {
   # On destroy: stop enclave + schedule KMS key deletion via supervisor.
   # Must run while the instance is still alive (before EC2 termination).
   provisioner "local-exec" {
-    when       = destroy
-    command    = <<-EOT
+    when    = destroy
+    command = <<-EOT
       aws ssm send-command \
         --instance-ids ${self.id} \
         --document-name AWS-RunShellScript \

--- a/test/run.sh
+++ b/test/run.sh
@@ -226,8 +226,12 @@ export AWS_ENDPOINT_URL_S3="${AWS_ENDPOINT_URL_S3:-http://127.0.0.1:4566}"
 
 tofu_apply() {
   # Always regenerate tfvars — paths differ between host and Docker.
-  # `enclave tofu` also ensures the tofu/ scaffold is present (merge-only-new,
-  # so pre-existing test-app files are left alone) before rewriting tfvars.
+  # `enclave tofu` is merge-only-new (existing files are skipped) so the
+  # committed test-app scaffold would mask CLI changes. Delete the
+  # CLI-managed root and module main.tf first to force a fresh emit; the
+  # rest of the tree (modules/backend, templates, etc.) is left untouched.
+  rm -f "${TOFU_DIR}/main.tf" "${TOFU_DIR}/modules/enclave/main.tf"
+
   echo "  Generating terraform.tfvars.json..."
 
   # Ensure artifact placeholders exist for tofu's filemd5() (local mode
@@ -275,6 +279,19 @@ OVERRIDE
 
   echo "  tofu init..."
   tofu -chdir="$TOFU_DIR" init -input=false > ${SCRIPT_DIR}/tofu-init.log 2>&1 || { cat ${SCRIPT_DIR}/tofu-init.log; return 1; }
+  # env_values overrides are supplied via an auto-loaded tfvars file (the env-file
+  # mechanism). tofu auto-loads any *.auto.tfvars.json next to the root module on
+  # every plan/apply, so overrides stick across both the initial deploy and the
+  # later migration apply without us repeating them on the command line.
+  cat > "${TOFU_DIR}/env_values.auto.tfvars.json" <<EOF
+{
+  "env_values": {
+    "TEST_RUNTIME_OVERRIDE": "override-from-tofu",
+    "TEST_RUNTIME_OVERRIDE_ENVFILE": "override-from-envfile"
+  }
+}
+EOF
+
   echo "  tofu apply..."
   tofu -chdir="$TOFU_DIR" apply -auto-approve -input=false -compact-warnings > ${SCRIPT_DIR}/tofu-apply.log 2>&1 || { echo "  tofu apply FAILED:"; tail -20 ${SCRIPT_DIR}/tofu-apply.log; return 1; }
   echo "  tofu apply OK (log: ${SCRIPT_DIR}/tofu-apply.log)"
@@ -609,6 +626,25 @@ if [ "$MIG_PENDING" = "false" ]; then
   echo "  PASS: No migration pending before deploy"
 else
   echo "  FAIL: migration_pending should be false before deploy (got: ${MIG_PENDING})" >&2
+  exit 1
+fi
+
+# Verify tofu's app.env overrides (supplied via env_values.auto.tfvars.json)
+# flowed through SSM into the running app. Both keys default to "default-from-yaml"
+# in enclave.yaml; the env file overrides them with distinct values.
+ENV_OVERRIDE_RESP=$(curl -sk --max-time 10 "https://localhost:${HOST_TLS_PORT:-8443}/test/env-override" 2>/dev/null || echo "")
+ENV_OVERRIDE_VAL=$(echo "$ENV_OVERRIDE_RESP" | jq -r '.test_runtime_override // empty' 2>/dev/null || echo "")
+ENV_OVERRIDE_ENVFILE_VAL=$(echo "$ENV_OVERRIDE_RESP" | jq -r '.test_runtime_override_envfile // empty' 2>/dev/null || echo "")
+if [ "$ENV_OVERRIDE_VAL" = "override-from-tofu" ]; then
+  echo "  PASS: app.env override applied (TEST_RUNTIME_OVERRIDE=${ENV_OVERRIDE_VAL})"
+else
+  printf "  FAIL: app.env override not applied — got %q, want \"override-from-tofu\" (response: %s)\n" "$ENV_OVERRIDE_VAL" "${ENV_OVERRIDE_RESP:0:120}" >&2
+  exit 1
+fi
+if [ "$ENV_OVERRIDE_ENVFILE_VAL" = "override-from-envfile" ]; then
+  echo "  PASS: env-file override applied (TEST_RUNTIME_OVERRIDE_ENVFILE=${ENV_OVERRIDE_ENVFILE_VAL})"
+else
+  printf "  FAIL: env-file override not applied — got %q, want \"override-from-envfile\" (response: %s)\n" "$ENV_OVERRIDE_ENVFILE_VAL" "${ENV_OVERRIDE_RESP:0:120}" >&2
   exit 1
 fi
 echo ""


### PR DESCRIPTION
app.env in enclave.yaml now serves as both build-time defaults baked into the EIF (contributing to PCR0) and a tofu-overridable runtime value. tofu writes each env_values entry to SSM at /<deployment>/<app>/env/<key>; the runtime overlays it on top of the baked default at boot. PCR0 stays identical across overrides — the schema (key set) is attested, the values are not.

Three ways to supply env_values, in increasing precedence: TF_VAR_env_values environment variable, *.auto.tfvars.json file (next to the root module), or -var on the command line.

- cli/framework_files.go: bake ENCLAVE_APP_ENV_KEYS in all four flake templates (go, nodejs, dotnet, rust)
- cli/tofu_files.go: env_values variable + aws_ssm_parameter.env_override resource; IAM widened to read /<deployment>/<app>/env/*
- runtime/env_overrides.go: applyEnvOverrides reads the baked schema, fetches each key from SSM, os.Setenv on hits; ParameterNotFound leaves the baked default intact. Called from Init after deleteOldKMSKey, before child spawn
- test/run.sh + test app: env_values.auto.tfvars.json with two keys; phase-5 assertions verify the override flow end-to-end
- README + scaffolded yaml comment: document the three mechanisms