### PR TITLE
feat: add vendor support for Go and Rust applications

### DIFF
--- a/BINARY-CACHE.md
+++ b/BINARY-CACHE.md
@@ -1,20 +1,8 @@
-# Binary cache + reproducible nixpkgs
+# Binary cache + reproducible nixpkgs — setup guide
 
-`enclave build` is a Nix build. If any transitive dependency moves upstream —
-a Cargo crate yanked, a GitHub repo renamed, a tarball removed — the rebuild
-fails. Production EIFs that ran for months can become un-rebuildable from
-one upstream event. See [ArkLabsHQ/enclave#127](https://github.com/ArkLabsHQ/enclave/issues/127)
-for the failure mode that motivated this feature.
-
-Two complementary tools fix it:
-
-| Tool | What it solves |
-|---|---|
-| **Cachix binary cache** | Once an EIF is built, it can be re-served byte-identically from cache — regardless of upstream state. |
-| **Pinned nixpkgs commit** | Stops the derivation graph from changing under you when the nixpkgs branch tip moves. |
-
-Use both together. The cache without the pin only delays the inevitable —
-when nixpkgs moves, the graph changes and the cache misses.
+See [README.md — Reproducible Build](README.md#reproducible-build) for the
+overview: what each layer protects, when to use each command, and the yaml
+schema. This document covers the step-by-step setup.
 
 ## 1. Set up Cachix (one-time)
 
@@ -44,27 +32,40 @@ nix profile install nixpkgs#cachix
 
 ## 2. Pin nixpkgs
 
-```sh
-enclave nixpkgs pin --latest
-```
-
-This:
-- queries `git ls-remote` for the tip of `nixos-25.11`,
-- computes the SRI hash via `nix-prefetch-url --unpack`,
-- writes `nix.nixpkgs_rev` + `nix.nixpkgs_hash` to `enclave/enclave.yaml`,
-- rewrites `enclave/flake.nix`'s `nixpkgs.url` line to point at the commit.
-
-Validate the pin without bumping:
+The framework ships a pinned `nixpkgs` SHA in every release (alongside the
+`aws-nitro-util` and `flake-utils` pins), so new projects are reproducible
+by default without any extra steps. You only need `enclave nixpkgs pin` when
+you want to **upgrade** to a newer nixpkgs commit — for example to pick up
+security patches or a newer toolchain version.
 
 ```sh
-enclave nixpkgs pin --check
+enclave nixpkgs pin
 ```
 
-Follow a different branch:
+What it does:
+1. `git ls-remote github.com/NixOS/nixpkgs refs/heads/nixos-25.11` → gets the current tip SHA
+2. `nix-prefetch-url --unpack` on the tarball → computes the SRI hash
+3. Writes `nix.nixpkgs_rev` + `nix.nixpkgs_hash` to `enclave/enclave.yaml`
+4. Rewrites `nixpkgs.url` in `enclave/flake.nix` to point at the SHA
+
+After running, commit both files:
 
 ```sh
-enclave nixpkgs pin --latest --branch nixos-unstable
+git add enclave/enclave.yaml enclave/flake.nix
+git commit -m "bump nixpkgs pin"
 ```
+
+This is an intentional EIF change — the new derivation graph produces a
+different PCR0. Deploy it through the normal migration flow.
+
+**Validate the existing pin without any network access:**
+
+```sh
+enclave nixpkgs pin --check   # exits 0 if rev + hash are well-formed
+```
+
+**Requirements:** `git` and `nix-prefetch-url` (part of any Nix installation)
+must be on PATH.
 
 ## 3. Build and push
 
@@ -114,7 +115,7 @@ Bumping picks up upstream security patches. It is an intentional EIF change —
 the new PCR0 needs to go through normal migration.
 
 ```sh
-enclave nixpkgs pin --latest        # writes new rev + hash + flake.nix
+enclave nixpkgs pin        # writes new rev + hash + flake.nix
 git add enclave/enclave.yaml enclave/flake.nix
 git commit -m "bump nixpkgs pin (CVE-XXXX-YYYY)"
 enclave build --push-cache          # populate cache with new closure
@@ -160,7 +161,7 @@ PCR0 — that requires building the actual derivation.
   (the `AwsNitroUtilRef` and `FlakeUtilsRef` constants in `cli/framework_files.go`).
   Bumping is a framework-release activity, not per-project. `follows` declarations
   collapse their transitive inputs onto the operator's `nixpkgs` pin.
-- **`enclave nixpkgs pin --latest` requires `git`, `nix`, and network
+- **`enclave nixpkgs pin` requires `git`, `nix`, and network
   access.** Surface the install hints from the error messages.
 - **`flake.lock` may go stale relative to the rev in `enclave.yaml`.** If you
   see drift, delete `enclave/flake.lock` and re-run `enclave build` to
@@ -241,5 +242,5 @@ transitive flake input that wasn't there before. The lockfile is your safety
 net.
 
 The file is small (a few hundred lines of JSON), regenerated only when you
-intentionally update inputs (`nix flake update` or `enclave nixpkgs pin
---latest`), and the diff is reviewable.
+intentionally update inputs (`nix flake update` or `enclave nixpkgs pin`),
+and the diff is reviewable.

--- a/BINARY-CACHE.md
+++ b/BINARY-CACHE.md
@@ -156,8 +156,10 @@ PCR0 — that requires building the actual derivation.
 
 - **Cachix free-tier limit is 5 GB.** Rust EIFs are 200 MB – 1 GB each. Watch
   your usage in the Cachix dashboard.
-- **`aws-nitro-util.url` and `flake-utils.url` are still branch references.**
-  Same problem class as nixpkgs. Tracked separately as a follow-up.
+- **`aws-nitro-util.url` and `flake-utils.url` are framework-pinned commits**
+  (the `AwsNitroUtilRef` and `FlakeUtilsRef` constants in `cli/framework_files.go`).
+  Bumping is a framework-release activity, not per-project. `follows` declarations
+  collapse their transitive inputs onto the operator's `nixpkgs` pin.
 - **`enclave nixpkgs pin --latest` requires `git`, `nix`, and network
   access.** Surface the install hints from the error messages.
 - **`flake.lock` may go stale relative to the rev in `enclave.yaml`.** If you

--- a/BINARY-CACHE.md
+++ b/BINARY-CACHE.md
@@ -1,0 +1,243 @@
+# Binary cache + reproducible nixpkgs
+
+`enclave build` is a Nix build. If any transitive dependency moves upstream —
+a Cargo crate yanked, a GitHub repo renamed, a tarball removed — the rebuild
+fails. Production EIFs that ran for months can become un-rebuildable from
+one upstream event. See [ArkLabsHQ/enclave#127](https://github.com/ArkLabsHQ/enclave/issues/127)
+for the failure mode that motivated this feature.
+
+Two complementary tools fix it:
+
+| Tool | What it solves |
+|---|---|
+| **Cachix binary cache** | Once an EIF is built, it can be re-served byte-identically from cache — regardless of upstream state. |
+| **Pinned nixpkgs commit** | Stops the derivation graph from changing under you when the nixpkgs branch tip moves. |
+
+Use both together. The cache without the pin only delays the inevitable —
+when nixpkgs moves, the graph changes and the cache misses.
+
+## 1. Set up Cachix (one-time)
+
+1. Sign up at <https://app.cachix.org> and create a cache (free tier = 5 GB).
+2. Copy the **public key** from the cache settings page.
+3. Generate a **personal auth token** at <https://app.cachix.org/personal-auth-tokens>.
+
+Add the cache details to `enclave/enclave.yaml`:
+
+```yaml
+nix:
+  substituters:
+    - "https://your-cache.cachix.org"      # only Cachix URLs are accepted
+  trusted_public_keys:
+    - "your-cache.cachix.org-1:<base64-key>="
+```
+
+Only `https://<name>.cachix.org` URLs are accepted. S3/Attic/self-hosted
+backends are rejected at config load — this is intentional. See the
+"Other backends" section at the bottom.
+
+Install the `cachix` CLI on machines that push:
+
+```sh
+nix profile install nixpkgs#cachix
+```
+
+## 2. Pin nixpkgs
+
+```sh
+enclave nixpkgs pin --latest
+```
+
+This:
+- queries `git ls-remote` for the tip of `nixos-25.11`,
+- computes the SRI hash via `nix-prefetch-url --unpack`,
+- writes `nix.nixpkgs_rev` + `nix.nixpkgs_hash` to `enclave/enclave.yaml`,
+- rewrites `enclave/flake.nix`'s `nixpkgs.url` line to point at the commit.
+
+Validate the pin without bumping:
+
+```sh
+enclave nixpkgs pin --check
+```
+
+Follow a different branch:
+
+```sh
+enclave nixpkgs pin --latest --branch nixos-unstable
+```
+
+## 3. Build and push
+
+```sh
+export CACHIX_AUTH_TOKEN=...
+enclave build --push-cache
+```
+
+The closure (sources + intermediate derivations + the final EIF) is pushed
+to the first substituter. Subsequent `enclave build` invocations on any
+machine resolve from the cache instead of fetching upstream.
+
+## 4. Wire into GitHub Actions
+
+The scaffolded `.github/workflows/build-eif.yml` and
+`.github/workflows/deploy-enclave.yml` already include a `Setup Cachix` step
+gated on a repo variable. To enable it, set two values under your repo's
+**Settings → Secrets and variables → Actions**:
+
+| Kind | Name | Value |
+|---|---|---|
+| Variable | `CACHIX_CACHE_NAME` | the cache name from the URL, e.g. `merlin` for `https://merlin.cachix.org` |
+| Secret | `CACHIX_AUTH_TOKEN` | the personal auth token from <https://app.cachix.org/personal-auth-tokens> |
+
+When `CACHIX_CACHE_NAME` is unset, the step is skipped and the workflow runs
+without the cache (same as today). When both are set, `cachix-action`:
+
+- wires the substituter into `nix.conf` before the build (pull cached paths),
+- pushes any newly-built paths to Cachix at job end (no need for `--push-cache` in CI).
+
+`--push-cache` is for local dev and non-GHA CI (GitLab, Jenkins, etc.) where
+the cachix-action isn't available.
+
+## Reproducing a six-month-old EIF
+
+```sh
+git checkout <old-commit>     # the enclave.yaml at the time of original build
+enclave build                  # cache hit on the closure — no upstream fetch
+sha384sum .enclave/artifacts/image.eif
+# Identical to the original PCR0 (the pinned nixpkgs + cached crates guarantee
+# byte-identical output).
+```
+
+## Bumping the pin
+
+Bumping picks up upstream security patches. It is an intentional EIF change —
+the new PCR0 needs to go through normal migration.
+
+```sh
+enclave nixpkgs pin --latest        # writes new rev + hash + flake.nix
+git add enclave/enclave.yaml enclave/flake.nix
+git commit -m "bump nixpkgs pin (CVE-XXXX-YYYY)"
+enclave build --push-cache          # populate cache with new closure
+# Deploy as a normal migration.
+```
+
+The `git log enclave/enclave.yaml` history is your audit trail.
+
+## Other backends
+
+The framework only supports Cachix. To add S3, Attic, or self-hosted backends
+would require:
+
+- a separate URL-format validator,
+- a separate push command per backend,
+- per-backend auth conventions in docs.
+
+Open an issue describing your requirements before submitting a patch — the
+validation is intentionally strict, not an oversight.
+
+## Trust model
+
+Closures live on cachix.org. This is acceptable because:
+
+- The cache contains BUILD OUTPUTS, not cryptographic material.
+- The enclave's KMS-protected keys are generated inside the Nitro VM at boot;
+  they never appear in any derivation.
+- Cache entries are content-addressed by hash. A compromised cache can serve
+  garbage but cannot serve "different code with the same hash."
+- The public-key check in `trusted_public_keys` is signature verification on
+  the narinfo (Nix's per-store-path metadata). Even a cache operator cannot
+  substitute a different binary under your store path.
+
+Worst case from `CACHIX_AUTH_TOKEN` leakage: an attacker pushes spam to your
+cache (which counts against your storage quota). They cannot push under your
+PCR0 — that requires building the actual derivation.
+
+## Limits and caveats
+
+- **Cachix free-tier limit is 5 GB.** Rust EIFs are 200 MB – 1 GB each. Watch
+  your usage in the Cachix dashboard.
+- **`aws-nitro-util.url` and `flake-utils.url` are still branch references.**
+  Same problem class as nixpkgs. Tracked separately as a follow-up.
+- **`enclave nixpkgs pin --latest` requires `git`, `nix`, and network
+  access.** Surface the install hints from the error messages.
+- **`flake.lock` may go stale relative to the rev in `enclave.yaml`.** If you
+  see drift, delete `enclave/flake.lock` and re-run `enclave build` to
+  regenerate it under the new pin.
+
+## Vendor mode (Rust + Go) — survives upstream dep disappearance
+
+Cachix protects rebuilds **once the cache has been populated**. But a fresh
+build with no cache history still fails when an upstream crate disappears.
+For belt-and-suspenders coverage, the framework supports an opt-in vendor
+mode that switches Nix to use a committed `vendor/` directory in the app
+source — no network access for app deps regardless of cache state.
+
+Supported for `language: rust` and `language: go` only.
+
+- **Node.js** has no clean vendor-mode equivalent in `buildNpmPackage`
+  (`npmDepsHash` is mandatory).
+- **.NET** already vendors via `nugetDeps = ./deps.json` — every package is
+  manifest-pinned with content-addressed fetches, so the equivalent
+  protection is already on.
+
+### Opt-in workflow
+
+Order matters: flip `vendor: true` BEFORE running `enclave setup`. Otherwise setup runs a trial Nix build to compute the vendor hash, which fetches from crates.io / the Go module proxy — and that's exactly the upstream you're trying to escape from in the recovery scenario.
+
+```sh
+# 1. In the upstream app's repo (NOT the framework repo):
+cd ~/my-app
+enclave vendor --path .       # runs `cargo vendor` (Rust) or `go mod vendor` (Go)
+git add vendor/
+git commit -m "vendor deps"
+git push
+
+# 2. Edit enclave/enclave.yaml:
+#    set app.vendor: true
+#    clear app.nix_vendor_hash (now unused; validation rejects setting both)
+
+# 3. From the framework / project root:
+enclave setup                 # sees vendor: true, skips hash discovery, refreshes nix_rev + nix_hash
+
+# 4. Build as normal — Nix uses vendor/, no upstream fetch for app deps
+enclave build
+```
+
+`enclave vendor` honours `app.nix_subdir` (changes into the subdir before
+running `cargo vendor` / `go mod vendor`).
+
+### How it complements Cachix
+
+Vendor and cache cover different layers of the closure:
+
+| Layer | Pin (in flake URLs) | Vendor (in repo) | Cachix |
+|---|---|---|---|
+| App source deps (Cargo / Go modules) | ✅ via lockfile + hash | ✅ explicit `vendor/` | ✅ if cached |
+| Runtime supervisor + deps | ✅ | ❌ | ✅ if cached |
+| nixpkgs + framework Nix inputs | ✅ | ❌ | ✅ if cached |
+
+Vendor cuts the app-source fetch step entirely; Cachix still serves
+everything else (nixpkgs, runtime, aws-nitro-util tooling) for fast rebuilds.
+Use both for maximum robustness — neither subsumes the other.
+
+### Trade-off
+
+`vendor/` adds 100 MB – 1 GB to the upstream app repo (depending on dep
+count). Reviewable in PRs (vendored crate source is plain text); just bulky.
+For long-lived projects where every rebuild matters, the cost is worth it.
+
+## Commit `enclave/flake.lock`
+
+The scaffolded `enclave/flake.nix` pins every input (`nixpkgs`,
+`flake-utils`, `aws-nitro-util`) by commit SHA and uses `follows`
+declarations to collapse transitive inputs onto your top-level pins.
+
+Even with that, **commit `enclave/flake.lock`**. It captures any transitive
+input a future framework dep might introduce — `follows` only covers what you
+explicitly enumerate, and a new aws-nitro-util release could add a new
+transitive flake input that wasn't there before. The lockfile is your safety
+net.
+
+The file is small (a few hundred lines of JSON), regenerated only when you
+intentionally update inputs (`nix flake update` or `enclave nixpkgs pin
+--latest`), and the diff is reviewable.

--- a/README.md
+++ b/README.md
@@ -378,7 +378,10 @@ make install   # install to $GOPATH/bin
 | `enclave update` | Fast update: only nix_rev + nix_hash (code changes, no dep changes) |
 | `enclave tofu` | Generate OpenTofu deployment scaffold into ./tofu/ (merge-only-new). Pass `--remote` to pull EIF + supervisor from a GitHub Release at apply time instead of from local files. |
 | `enclave build` | Build EIF image (reproducible, via Docker + Nix) |
-| `enclave build` |  |
+| `enclave build --push-cache` | Build, then push the closure to the first Cachix substituter (requires `CACHIX_AUTH_TOKEN` + `cachix` CLI) |
+| `enclave nixpkgs pin --latest` | Pin `nixpkgs` to the tip of `nixos-25.11` (writes enclave.yaml + flake.nix). See [BINARY-CACHE.md](BINARY-CACHE.md). |
+| `enclave nixpkgs pin --check` | Validate the existing nixpkgs pin without bumping it |
+| `enclave vendor --path <dir>` | Run `cargo vendor` / `go mod vendor` in the upstream app source (language taken from enclave.yaml). Then commit `vendor/`, run `enclave setup`, and set `app.vendor: true`. |
 | `enclave deploy` | Deploy CDK stack (VPC, EC2, KMS, IAM, secrets) |
 | `enclave verify` | Verify attestation document and PCR0 against local build |
 | `enclave status` | Show deployment status |
@@ -582,6 +585,52 @@ The attestation proof is an NSM attestation document — a COSE Sign1 structure 
 
 The enclave image is built entirely with [Nix](https://nixos.org/) using [monzo/aws-nitro-util](https://github.com/monzo/aws-nitro-util) inside a pinned Docker container, producing a byte-identical EIF on every build. This guarantees identical PCR0 measurements, enabling anyone to verify that the running enclave matches the published source code.
 
+### Surviving upstream dep churn
+
+Nix fetches every transitive dependency from upstream on each build. If a Cargo crate is yanked, a GitHub repo is renamed, or any tarball disappears, the rebuild fails — your six-month-old EIF can become un-rebuildable from one upstream event.
+
+Two opt-in tools fix this:
+
+- **Cachix binary cache** — once an EIF is built, push the closure to a project-specific [Cachix](https://cachix.org) cache. Subsequent builds resolve from the cache, regardless of upstream state.
+- **Pinned nixpkgs commit** — pin `nixpkgs` to a specific SHA so the derivation graph stays stable even when the branch tip moves.
+
+Setup:
+
+```yaml
+# enclave/enclave.yaml
+nix:
+  substituters:
+    - "https://your-cache.cachix.org"   # only Cachix URLs are accepted
+  trusted_public_keys:
+    - "your-cache.cachix.org-1:<base64-key>="
+  nixpkgs_rev:  "<40-char commit SHA>"
+  nixpkgs_hash: "sha256-<SRI hash>"
+```
+
+```sh
+enclave nixpkgs pin --latest    # writes rev + hash, rewrites enclave/flake.nix
+enclave build --push-cache      # builds and pushes the closure to Cachix
+```
+
+Without these, the EIF still builds — but every rebuild needs upstream. See [BINARY-CACHE.md](BINARY-CACHE.md) for the full setup, trust model, and CI integration.
+
+### Vendor app source deps (optional, Rust + Go)
+
+Cachix protects rebuilds *after* the cache is populated. For belt-and-suspenders coverage that survives upstream disappearance regardless of cache state, vendor the app's dependencies into git:
+
+```sh
+enclave vendor --path ~/my-app   # cargo vendor (Rust) or go mod vendor (Go)
+git add vendor/ && git commit && git push
+enclave setup                    # refresh nix_rev/nix_hash
+# Set app.vendor: true in enclave.yaml; clear nix_vendor_hash
+```
+
+The Nix build then uses the committed `vendor/` tree — zero upstream fetch for app code. Complements Cachix (which still serves nixpkgs + runtime). See [BINARY-CACHE.md](BINARY-CACHE.md#vendor-mode-rust--go--survives-upstream-dep-disappearance) for the full workflow and trade-offs.
+
+### Commit `enclave/flake.lock`
+
+The scaffolded flake pins all framework inputs (`nixpkgs`, `flake-utils`, `aws-nitro-util`) by commit SHA in their URLs and uses `inputs.<dep>.inputs.<sub>.follows` declarations to collapse transitive inputs onto your top-level pins. That closes the derivation graph for everything the framework declares directly. **Commit `enclave/flake.lock` to git** as defense-in-depth — it pins any transitive flake inputs that a future framework upgrade might introduce, so PCR0 stays stable even when you bump framework deps.
+
 ## Local Testing
 
 The test suite runs a full enclave inside QEMU (`-M nitro-enclave`) with mock AWS services, executing 15 integration tests followed by a locked-key migration with post-migration verification.
@@ -723,9 +772,14 @@ The Docker test runner image (`test/Dockerfile.runner`) builds QEMU 9.2.4, vhost
 | `app.nix_vendor_hash` | Go vendor hash or npm deps hash (SRI) | (auto by `setup`) |
 | `app.nix_sub_packages` | Go sub-packages to build (Go only) | `["."]` |
 | `app.binary_name` | Output binary name | `{name}` |
+| `app.vendor` | (go/rust) Use committed `vendor/` in app source; mutually exclusive with `nix_vendor_hash`. See [BINARY-CACHE.md](BINARY-CACHE.md#vendor-mode-rust--go--survives-upstream-dep-disappearance). | `false` |
 | `app.env` | Environment variables baked into EIF as defaults (tofu can override per-deploy via `-var env_values={...}`) | `{}` |
 | `secrets[].name` | Secret name (SSM path component) | (required) |
 | `secrets[].env_var` | Env var for decrypted value | (required) |
+| `nix.substituters` | Cachix substituter URLs (`https://<name>.cachix.org`) — only Cachix is accepted | `[]` |
+| `nix.trusted_public_keys` | Public keys for the substituters above (Cachix shows on cache settings page) | `[]` |
+| `nix.nixpkgs_rev` | 40-char nixpkgs commit SHA — pins the derivation graph | `nixos-25.11` branch |
+| `nix.nixpkgs_hash` | SRI hash of the nixpkgs tarball at `nixpkgs_rev` | — |
 
 ### Environment Variables (Runtime)
 

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ make install   # install to $GOPATH/bin
 | `enclave tofu` | Generate OpenTofu deployment scaffold into ./tofu/ (merge-only-new). Pass `--remote` to pull EIF + supervisor from a GitHub Release at apply time instead of from local files. |
 | `enclave build` | Build EIF image (reproducible, via Docker + Nix) |
 | `enclave build --push-cache` | Build, then push the closure to the first Cachix substituter (requires `CACHIX_AUTH_TOKEN` + `cachix` CLI) |
-| `enclave nixpkgs pin --latest` | Pin `nixpkgs` to the tip of `nixos-25.11` (writes enclave.yaml + flake.nix). See [BINARY-CACHE.md](BINARY-CACHE.md). |
+| `enclave nixpkgs pin` | Pin `nixpkgs` to the tip of `nixos-25.11` (writes enclave.yaml + flake.nix). See [BINARY-CACHE.md](BINARY-CACHE.md). |
 | `enclave nixpkgs pin --check` | Validate the existing nixpkgs pin without bumping it |
 | `enclave vendor --path <dir>` | Run `cargo vendor` / `go mod vendor` in the upstream app source (language taken from enclave.yaml). Then commit `vendor/`, run `enclave setup`, and set `app.vendor: true`. |
 | `enclave deploy` | Deploy CDK stack (VPC, EC2, KMS, IAM, secrets) |
@@ -583,53 +583,70 @@ The attestation proof is an NSM attestation document — a COSE Sign1 structure 
 
 ## Reproducible Build
 
-The enclave image is built entirely with [Nix](https://nixos.org/) using [monzo/aws-nitro-util](https://github.com/monzo/aws-nitro-util) inside a pinned Docker container, producing a byte-identical EIF on every build. This guarantees identical PCR0 measurements, enabling anyone to verify that the running enclave matches the published source code.
+The enclave image is built entirely with [Nix](https://nixos.org/) using [monzo/aws-nitro-util](https://github.com/monzo/aws-nitro-util), producing a byte-identical EIF on every build. The framework pins every Nix input (`nixpkgs`, `flake-utils`, `aws-nitro-util`) to a specific commit SHA at release time — a fresh `enclave init` produces a fully deterministic build without any operator action.
 
-### Surviving upstream dep churn
+Three layers protect reproducibility against different failure modes:
 
-Nix fetches every transitive dependency from upstream on each build. If a Cargo crate is yanked, a GitHub repo is renamed, or any tarball disappears, the rebuild fails — your six-month-old EIF can become un-rebuildable from one upstream event.
+| Layer | What it protects | Status |
+|---|---|---|
+| **Pinned inputs** | Derivation graph stability (all Nix inputs at fixed SHAs) | ✅ Always on — framework-managed |
+| **Cachix cache** | Upstream source availability (yanked crates, deleted repos) | Opt-in — add `nix.substituters` |
+| **Vendor mode** | App source deps (Rust/Go) — survives first build with no cache | Opt-in — set `app.vendor: true` |
 
-Two opt-in tools fix this:
+### `nix:` yaml block
 
-- **Cachix binary cache** — once an EIF is built, push the closure to a project-specific [Cachix](https://cachix.org) cache. Subsequent builds resolve from the cache, regardless of upstream state.
-- **Pinned nixpkgs commit** — pin `nixpkgs` to a specific SHA so the derivation graph stays stable even when the branch tip moves.
-
-Setup:
+Cachix and the optional nixpkgs override are configured here:
 
 ```yaml
-# enclave/enclave.yaml
 nix:
   substituters:
     - "https://your-cache.cachix.org"   # only Cachix URLs are accepted
   trusted_public_keys:
     - "your-cache.cachix.org-1:<base64-key>="
-  nixpkgs_rev:  "<40-char commit SHA>"
-  nixpkgs_hash: "sha256-<SRI hash>"
+  nixpkgs_rev:  "25f5383..."            # written by `enclave nixpkgs pin`
+  nixpkgs_hash: "sha256-..."            # written by `enclave nixpkgs pin`
 ```
 
+All four fields are optional and independent. An empty `nix:` block (or no block at all) leaves the framework's built-in defaults in effect.
+
+### `enclave nixpkgs pin`
+
+The framework already ships a pinned `nixpkgs` SHA per release (same as `flake-utils` / `aws-nitro-util`), so new projects are pinned by default. Run this only when you want to **upgrade** to a newer nixpkgs — to pick up security patches or a newer compiler:
+
 ```sh
-enclave nixpkgs pin --latest    # writes rev + hash, rewrites enclave/flake.nix
-enclave build --push-cache      # builds and pushes the closure to Cachix
+enclave nixpkgs pin          # fetch nixos-25.11 tip → write to enclave.yaml + flake.nix
+enclave nixpkgs pin --check  # validate existing pin, no network
 ```
 
-Without these, the EIF still builds — but every rebuild needs upstream. See [BINARY-CACHE.md](BINARY-CACHE.md) for the full setup, trust model, and CI integration.
+After running, commit both changed files. The derivation graph changes → PCR0 changes → deploy via normal migration flow.
 
-### Vendor app source deps (optional, Rust + Go)
+### `enclave build --push-cache`
 
-Cachix protects rebuilds *after* the cache is populated. For belt-and-suspenders coverage that survives upstream disappearance regardless of cache state, vendor the app's dependencies into git:
+After a successful build, pushes the full EIF closure to your Cachix cache:
 
 ```sh
-enclave vendor --path ~/my-app   # cargo vendor (Rust) or go mod vendor (Go)
+CACHIX_AUTH_TOKEN=... enclave build --push-cache
+```
+
+Requires `cachix` CLI on PATH. In GitHub Actions, `cachix/cachix-action@v15` handles this automatically — set `vars.CACHIX_CACHE_NAME` and `secrets.CACHIX_AUTH_TOKEN` on the repo and the scaffolded workflows pick it up.
+
+### `enclave vendor` (Rust + Go only)
+
+Cachix protects rebuilds after the cache is populated. For coverage that survives upstream disappearance even on the first build (no cache history yet), vendor the app's source deps into git. Order matters — flip `app.vendor: true` before running `enclave setup`:
+
+```sh
+enclave vendor --path ~/my-app   # cargo vendor or go mod vendor
 git add vendor/ && git commit && git push
-enclave setup                    # refresh nix_rev/nix_hash
-# Set app.vendor: true in enclave.yaml; clear nix_vendor_hash
+# Edit enclave.yaml: app.vendor: true, clear nix_vendor_hash
+enclave setup                    # skips hash discovery; refreshes nix_rev/nix_hash
+enclave build                    # Nix uses committed vendor/, no upstream fetch
 ```
-
-The Nix build then uses the committed `vendor/` tree — zero upstream fetch for app code. Complements Cachix (which still serves nixpkgs + runtime). See [BINARY-CACHE.md](BINARY-CACHE.md#vendor-mode-rust--go--survives-upstream-dep-disappearance) for the full workflow and trade-offs.
 
 ### Commit `enclave/flake.lock`
 
-The scaffolded flake pins all framework inputs (`nixpkgs`, `flake-utils`, `aws-nitro-util`) by commit SHA in their URLs and uses `inputs.<dep>.inputs.<sub>.follows` declarations to collapse transitive inputs onto your top-level pins. That closes the derivation graph for everything the framework declares directly. **Commit `enclave/flake.lock` to git** as defense-in-depth — it pins any transitive flake inputs that a future framework upgrade might introduce, so PCR0 stays stable even when you bump framework deps.
+Commit `enclave/flake.lock` alongside your flake. It pins any transitive flake inputs introduced by future framework upgrades, ensuring the derivation graph stays fully closed even when you bump framework deps.
+
+See [BINARY-CACHE.md](BINARY-CACHE.md) for the full setup guide, Cachix account setup, CI integration (GitHub Actions), trust model, and vendor mode trade-offs.
 
 ## Local Testing
 

--- a/cli/build.go
+++ b/cli/build.go
@@ -46,6 +46,7 @@ type buildConfigAppJSON struct {
 	NixNativeBuildInputs []string          `json:"nix_native_build_inputs"`
 	BinaryName           string            `json:"binary_name"`
 	Env                  map[string]string `json:"env"`
+	Vendor               bool              `json:"vendor"`
 }
 
 type buildConfigSecretJSON struct {
@@ -67,16 +68,24 @@ func buildCmd() *cobra.Command {
 		RunE:  runBuild,
 	}
 	cmd.Flags().StringP("config", "c", "", "path to enclave.yaml (defaults to enclave/enclave.yaml or ./enclave.yaml). Use to build a test variant: `enclave build --config enclave/enclave_test.yaml`.")
+	cmd.Flags().Bool("push-cache", false, "Push the built EIF closure to the first Cachix substituter after a successful build. Requires CACHIX_AUTH_TOKEN env var and the `cachix` CLI on PATH.")
 	return cmd
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {
 	configPath, _ := cmd.Flags().GetString("config")
+	pushCache, _ := cmd.Flags().GetBool("push-cache")
 	cfg, err := loadConfigAt(configPath)
 	if err != nil {
 		return err
 	}
-	return runBuildWithConfig(cfg)
+	if err := runBuildWithConfig(cfg); err != nil {
+		return err
+	}
+	if pushCache {
+		return pushToCachix(cfg)
+	}
+	return nil
 }
 
 func runBuildWithConfig(cfg *Config) error {
@@ -179,6 +188,7 @@ func generateBuildConfig(cfg *Config, root string) error {
 			NixNativeBuildInputs: nonNilStrings(cfg.App.NixNativeBuildInputs),
 			BinaryName:           cfg.App.BinaryName,
 			Env:                  resolvedEnv,
+			Vendor:               cfg.App.Vendor,
 		},
 		Secrets: secrets,
 		Runtime: buildConfigRuntimeJSON{
@@ -252,13 +262,7 @@ func BuildEIF(cfg *Config, root string) (*PCRValues, error) {
 	}
 
 	// 3. Run nix build locally against ./enclave#eif.
-	nixCmd := exec.Command("nix", "build",
-		"--impure",
-		"--extra-experimental-features", "nix-command flakes",
-		"--option", "download-attempts", "3",
-		"--out-link", ".enclave/result",
-		"./enclave#eif",
-	)
+	nixCmd := exec.Command("nix", buildNixArgs(cfg)...)
 	nixCmd.Dir = root
 	nixCmd.Stdout = os.Stdout
 	nixCmd.Stderr = os.Stderr
@@ -342,5 +346,63 @@ func buildSupervisorBinary(cfg *Config, root string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("go install supervisor: %w", err)
 	}
+	return nil
+}
+
+// buildNixArgs returns the argv for `nix build`, including any Cachix
+// substituter / trusted-public-key options derived from cfg.Nix.
+// Extracted as a helper so the argv composition can be unit-tested.
+func buildNixArgs(cfg *Config) []string {
+	args := []string{
+		"build",
+		"--impure",
+		"--extra-experimental-features", "nix-command flakes",
+		"--option", "download-attempts", "3",
+	}
+	if len(cfg.Nix.Substituters) > 0 {
+		args = append(args, "--option", "extra-substituters", strings.Join(cfg.Nix.Substituters, " "))
+	}
+	if len(cfg.Nix.TrustedPublicKeys) > 0 {
+		args = append(args, "--option", "extra-trusted-public-keys", strings.Join(cfg.Nix.TrustedPublicKeys, " "))
+	}
+	args = append(args,
+		"--out-link", ".enclave/result",
+		"./enclave#eif",
+	)
+	return args
+}
+
+// pushToCachix pushes the just-built EIF closure to the first configured
+// Cachix substituter. Requires the `cachix` CLI on PATH and CACHIX_AUTH_TOKEN
+// in the environment. Surfaces install hints when the CLI is missing.
+func pushToCachix(cfg *Config) error {
+	if len(cfg.Nix.Substituters) == 0 {
+		return fmt.Errorf("--push-cache requires at least one entry in nix.substituters in enclave.yaml")
+	}
+	cacheName := CachixCacheName(cfg.Nix.Substituters[0])
+	if cacheName == "" {
+		return fmt.Errorf("--push-cache: nix.substituters[0] %q is not a Cachix URL", cfg.Nix.Substituters[0])
+	}
+	if _, err := exec.LookPath("cachix"); err != nil {
+		return fmt.Errorf("`cachix` CLI not found on PATH — install with: nix profile install nixpkgs#cachix (or see https://docs.cachix.org/installation)")
+	}
+	if os.Getenv("CACHIX_AUTH_TOKEN") == "" {
+		return fmt.Errorf("CACHIX_AUTH_TOKEN env var not set — create a token at https://app.cachix.org/personal-auth-tokens")
+	}
+
+	root, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+	resultLink := filepath.Join(root, ".enclave", "result")
+
+	fmt.Printf("[build] Pushing closure to cachix cache %q...\n", cacheName)
+	cmd := exec.Command("cachix", "push", cacheName, resultLink)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("cachix push: %w", err)
+	}
+	fmt.Printf("[build] Pushed closure to %s\n", cfg.Nix.Substituters[0])
 	return nil
 }

--- a/cli/build_test.go
+++ b/cli/build_test.go
@@ -228,3 +228,88 @@ func TestGenerateBuildConfig_BuildInputsNeverNull(t *testing.T) {
 		t.Errorf("JSON must not emit null for build-input lists, got:\n%s", raw)
 	}
 }
+
+func TestBuildNixArgs_NoCache(t *testing.T) {
+	cfg := &Config{}
+	args := buildNixArgs(cfg)
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "extra-substituters") {
+		t.Errorf("expected no extra-substituters when nix block is empty, got: %s", joined)
+	}
+	if !strings.Contains(joined, "./enclave#eif") {
+		t.Errorf("expected ./enclave#eif as the final build target, got: %s", joined)
+	}
+	if args[0] != "build" {
+		t.Errorf("expected first arg to be \"build\", got %q", args[0])
+	}
+}
+
+func TestBuildNixArgs_WithCache(t *testing.T) {
+	cfg := &Config{
+		Nix: NixConfig{
+			Substituters:      []string{"https://merlin.cachix.org", "https://shared.cachix.org"},
+			TrustedPublicKeys: []string{"merlin.cachix.org-1:abc=", "shared.cachix.org-1:def="},
+		},
+	}
+	args := buildNixArgs(cfg)
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "--option extra-substituters https://merlin.cachix.org https://shared.cachix.org") {
+		t.Errorf("expected extra-substituters in argv, got: %s", joined)
+	}
+	if !strings.Contains(joined, "--option extra-trusted-public-keys merlin.cachix.org-1:abc= shared.cachix.org-1:def=") {
+		t.Errorf("expected extra-trusted-public-keys in argv, got: %s", joined)
+	}
+	if !strings.Contains(joined, "./enclave#eif") {
+		t.Errorf("expected build target preserved, got: %s", joined)
+	}
+}
+
+func TestGenerateBuildConfig_VendorField(t *testing.T) {
+	for _, vendor := range []bool{true, false} {
+		t.Run(map[bool]string{true: "vendor=true", false: "vendor=false"}[vendor], func(t *testing.T) {
+			root := t.TempDir()
+			cfg := &Config{
+				Name:    "app",
+				Version: "1.0.0",
+				Region:  "us-east-1",
+				App: AppConfig{
+					Language:   "rust",
+					BinaryName: "app",
+					Vendor:     vendor,
+				},
+				MigrationCooldown: "0s",
+				PreviousPCR0:      "genesis",
+			}
+			if err := generateBuildConfig(cfg, root); err != nil {
+				t.Fatalf("generateBuildConfig: %v", err)
+			}
+			data, err := os.ReadFile(filepath.Join(root, ".enclave", "build-config.json"))
+			if err != nil {
+				t.Fatal(err)
+			}
+			var bc buildConfigJSON
+			if err := json.Unmarshal(data, &bc); err != nil {
+				t.Fatal(err)
+			}
+			if bc.App.Vendor != vendor {
+				t.Errorf("bc.App.Vendor = %v, want %v", bc.App.Vendor, vendor)
+			}
+		})
+	}
+}
+
+func TestBuildNixArgs_KeysWithoutSubstituters(t *testing.T) {
+	cfg := &Config{
+		Nix: NixConfig{
+			TrustedPublicKeys: []string{"merlin.cachix.org-1:abc="},
+		},
+	}
+	args := buildNixArgs(cfg)
+	joined := strings.Join(args, " ")
+	if strings.Contains(joined, "extra-substituters") {
+		t.Errorf("expected no extra-substituters, got: %s", joined)
+	}
+	if !strings.Contains(joined, "extra-trusted-public-keys") {
+		t.Errorf("trusted_public_keys should still be plumbed through even without substituters, got: %s", joined)
+	}
+}

--- a/cli/config.go
+++ b/cli/config.go
@@ -2,19 +2,24 @@ package cli
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"regexp"
+	"strings"
 	"time"
 
 	"gopkg.in/yaml.v3"
 )
 
 var (
-	accountIDRegex  = regexp.MustCompile(`^\d{12}$`)
-	secretNameRegex = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
-	envVarRegex     = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
-	fqdnRegex       = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+	accountIDRegex   = regexp.MustCompile(`^\d{12}$`)
+	secretNameRegex  = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9_]*$`)
+	envVarRegex      = regexp.MustCompile(`^[A-Z][A-Z0-9_]*$`)
+	fqdnRegex        = regexp.MustCompile(`^([a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?\.)+[a-zA-Z]{2,}$`)
+	commitSHARegex   = regexp.MustCompile(`^[0-9a-f]{40}$`)
+	cachixHostRegex  = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*\.cachix\.org$`)
+	publicKeyRegex   = regexp.MustCompile(`^[A-Za-z0-9._-]+:[A-Za-z0-9+/]+=*$`)
 )
 
 // reservedEnvPrefixes lists env var prefixes that must not be used for secrets.
@@ -54,6 +59,18 @@ type Config struct {
 	//     can decrypt. Permanent at first lock.
 	IsKMSKeyLocked bool      `yaml:"is_kms_key_locked"`
 	TLS            TLSConfig `yaml:"tls"`
+	Nix            NixConfig `yaml:"nix"`
+}
+
+// NixConfig configures Nix binary caching and reproducibility for EIF builds.
+// Only Cachix is supported as a substituter backend — config-load rejects
+// any other URL. NixpkgsRev pins the flake's nixpkgs input to a specific
+// commit so the derivation graph is stable across builds.
+type NixConfig struct {
+	Substituters      []string `yaml:"substituters"`
+	TrustedPublicKeys []string `yaml:"trusted_public_keys"`
+	NixpkgsRev        string   `yaml:"nixpkgs_rev"`
+	NixpkgsHash       string   `yaml:"nixpkgs_hash"`
 }
 
 type AppConfig struct {
@@ -75,6 +92,11 @@ type AppConfig struct {
 	// which `enclave tofu init --remote` downloads image.eif and supervisor.
 	// Defaults to "eif-latest" when unset.
 	ReleaseTag string `yaml:"release_tag"`
+	// Vendor switches the flake into vendor mode — Nix uses a committed
+	// vendor/ directory in the source tree instead of fetching deps via
+	// cargoHash/vendorHash. Survives upstream dep disappearance regardless
+	// of cache state. Only supported for language=go|rust.
+	Vendor bool `yaml:"vendor"`
 }
 
 // SecretConfig defines a secret managed by KMS inside the enclave.
@@ -227,7 +249,74 @@ func loadConfigAt(configPath string) (*Config, error) {
 		return nil, fmt.Errorf("%s: tls.route53_zone_id requires tls.fqdn to be set", configFile)
 	}
 
+	if cfg.App.Vendor {
+		switch cfg.App.Language {
+		case "go", "rust":
+		default:
+			return nil, fmt.Errorf("%s: app.vendor=true is only supported for language go|rust (got %q). Node uses npmDepsHash; .NET uses nugetDeps — both already manifest-pinned.", configFile, cfg.App.Language)
+		}
+		if cfg.App.NixVendorHash != "" {
+			return nil, fmt.Errorf("%s: app.vendor=true is mutually exclusive with app.nix_vendor_hash (vendor mode uses the committed vendor/ directory; no hash needed). Clear nix_vendor_hash to switch to vendor mode.", configFile)
+		}
+	}
+
+	if err := validateNixConfig(&cfg.Nix, configPath); err != nil {
+		return nil, err
+	}
+
 	return &cfg, nil
+}
+
+// validateNixConfig enforces the Cachix-only substituter rule and the
+// well-formed-pin invariant. Substituters must be https://<name>.cachix.org;
+// any other URL is rejected. NixpkgsRev/Hash must both be set together.
+func validateNixConfig(n *NixConfig, configPath string) error {
+	if len(n.Substituters) > 0 && len(n.TrustedPublicKeys) == 0 {
+		return fmt.Errorf("%s: nix.substituters set but nix.trusted_public_keys empty (Cachix shows the public key on the cache settings page)", configPath)
+	}
+	for i, s := range n.Substituters {
+		u, err := url.Parse(s)
+		if err != nil || u.Scheme != "https" || !cachixHostRegex.MatchString(u.Host) {
+			return fmt.Errorf("%s: nix.substituters[%d] %q is not a Cachix URL — only https://<name>.cachix.org is supported", configPath, i, s)
+		}
+		if u.Path != "" && u.Path != "/" {
+			return fmt.Errorf("%s: nix.substituters[%d] %q must not include a path", configPath, i, s)
+		}
+	}
+	for i, k := range n.TrustedPublicKeys {
+		if !publicKeyRegex.MatchString(k) {
+			return fmt.Errorf("%s: nix.trusted_public_keys[%d] %q must be in <name>:<base64> format", configPath, i, k)
+		}
+	}
+	if n.NixpkgsRev != "" || n.NixpkgsHash != "" {
+		if n.NixpkgsRev == "" || n.NixpkgsHash == "" {
+			return fmt.Errorf("%s: nix.nixpkgs_rev and nix.nixpkgs_hash must both be set (use `enclave nixpkgs pin --latest`)", configPath)
+		}
+		if !commitSHARegex.MatchString(n.NixpkgsRev) {
+			return fmt.Errorf("%s: nix.nixpkgs_rev %q must be a 40-char hex commit SHA", configPath, n.NixpkgsRev)
+		}
+		if !strings.HasPrefix(n.NixpkgsHash, "sha256-") {
+			return fmt.Errorf("%s: nix.nixpkgs_hash %q must start with 'sha256-' (SRI format)", configPath, n.NixpkgsHash)
+		}
+	}
+	return nil
+}
+
+// CachixCacheName extracts the cache name from a Cachix substituter URL.
+// Returns "" if the URL is not a well-formed Cachix URL (wrong scheme, host,
+// or includes any path/query/fragment).
+func CachixCacheName(substituter string) string {
+	u, err := url.Parse(substituter)
+	if err != nil || u.Scheme != "https" || !cachixHostRegex.MatchString(u.Host) {
+		return ""
+	}
+	if u.Path != "" && u.Path != "/" {
+		return ""
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return ""
+	}
+	return strings.TrimSuffix(u.Host, ".cachix.org")
 }
 
 // validateAccount checks that the AWS account ID is present and valid.

--- a/cli/config.go
+++ b/cli/config.go
@@ -20,6 +20,8 @@ var (
 	commitSHARegex   = regexp.MustCompile(`^[0-9a-f]{40}$`)
 	cachixHostRegex  = regexp.MustCompile(`^[a-z0-9][a-z0-9-]*\.cachix\.org$`)
 	publicKeyRegex   = regexp.MustCompile(`^[A-Za-z0-9._-]+:[A-Za-z0-9+/]+=*$`)
+	// SRI sha256: "sha256-" + 43 base64 chars + "=" (32 raw bytes → 44 base64).
+	sriSha256Regex   = regexp.MustCompile(`^sha256-[A-Za-z0-9+/]{43}=$`)
 )
 
 // reservedEnvPrefixes lists env var prefixes that must not be used for secrets.
@@ -295,8 +297,8 @@ func validateNixConfig(n *NixConfig, configPath string) error {
 		if !commitSHARegex.MatchString(n.NixpkgsRev) {
 			return fmt.Errorf("%s: nix.nixpkgs_rev %q must be a 40-char hex commit SHA", configPath, n.NixpkgsRev)
 		}
-		if !strings.HasPrefix(n.NixpkgsHash, "sha256-") {
-			return fmt.Errorf("%s: nix.nixpkgs_hash %q must start with 'sha256-' (SRI format)", configPath, n.NixpkgsHash)
+		if !sriSha256Regex.MatchString(n.NixpkgsHash) {
+			return fmt.Errorf("%s: nix.nixpkgs_hash %q must be SRI-formatted sha256 ('sha256-' + 43 base64 chars + '=')", configPath, n.NixpkgsHash)
 		}
 	}
 	return nil

--- a/cli/config.go
+++ b/cli/config.go
@@ -292,7 +292,7 @@ func validateNixConfig(n *NixConfig, configPath string) error {
 	}
 	if n.NixpkgsRev != "" || n.NixpkgsHash != "" {
 		if n.NixpkgsRev == "" || n.NixpkgsHash == "" {
-			return fmt.Errorf("%s: nix.nixpkgs_rev and nix.nixpkgs_hash must both be set (use `enclave nixpkgs pin --latest`)", configPath)
+			return fmt.Errorf("%s: nix.nixpkgs_rev and nix.nixpkgs_hash must both be set (use `enclave nixpkgs pin`)", configPath)
 		}
 		if !commitSHARegex.MatchString(n.NixpkgsRev) {
 			return fmt.Errorf("%s: nix.nixpkgs_rev %q must be a 40-char hex commit SHA", configPath, n.NixpkgsRev)

--- a/cli/config.go
+++ b/cli/config.go
@@ -253,10 +253,10 @@ func loadConfigAt(configPath string) (*Config, error) {
 		switch cfg.App.Language {
 		case "go", "rust":
 		default:
-			return nil, fmt.Errorf("%s: app.vendor=true is only supported for language go|rust (got %q). Node uses npmDepsHash; .NET uses nugetDeps — both already manifest-pinned.", configFile, cfg.App.Language)
+			return nil, fmt.Errorf("%s: app.vendor=true is only supported for language go|rust (got %q) — Node uses npmDepsHash and .NET uses nugetDeps, both already manifest-pinned", configFile, cfg.App.Language)
 		}
 		if cfg.App.NixVendorHash != "" {
-			return nil, fmt.Errorf("%s: app.vendor=true is mutually exclusive with app.nix_vendor_hash (vendor mode uses the committed vendor/ directory; no hash needed). Clear nix_vendor_hash to switch to vendor mode.", configFile)
+			return nil, fmt.Errorf("%s: app.vendor=true is mutually exclusive with app.nix_vendor_hash — clear nix_vendor_hash to switch to vendor mode (vendor mode uses the committed vendor/ directory; no hash needed)", configFile)
 		}
 	}
 

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -339,6 +339,312 @@ func TestLoadConfig_TLSDefault(t *testing.T) {
 	}
 }
 
+func TestLoadConfig_NixCacheValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		nix     string
+		wantErr bool
+	}{
+		{
+			name: "valid cachix substituter with key",
+			nix: `nix:
+  substituters:
+    - "https://merlin.cachix.org"
+  trusted_public_keys:
+    - "merlin.cachix.org-1:abcDEF123+/="
+`,
+		},
+		{
+			name: "substituters without keys",
+			nix: `nix:
+  substituters:
+    - "https://merlin.cachix.org"
+`,
+			wantErr: true,
+		},
+		{
+			name: "non-cachix substituter rejected",
+			nix: `nix:
+  substituters:
+    - "https://my-cache.s3.amazonaws.com"
+  trusted_public_keys:
+    - "k:abc="
+`,
+			wantErr: true,
+		},
+		{
+			name: "self-hosted attic rejected",
+			nix: `nix:
+  substituters:
+    - "https://attic.example.com"
+  trusted_public_keys:
+    - "k:abc="
+`,
+			wantErr: true,
+		},
+		{
+			name: "http (not https) rejected",
+			nix: `nix:
+  substituters:
+    - "http://merlin.cachix.org"
+  trusted_public_keys:
+    - "k:abc="
+`,
+			wantErr: true,
+		},
+		{
+			name: "cachix subdomain with path rejected",
+			nix: `nix:
+  substituters:
+    - "https://merlin.cachix.org/v1"
+  trusted_public_keys:
+    - "k:abc="
+`,
+			wantErr: true,
+		},
+		{
+			name: "malformed public key rejected",
+			nix: `nix:
+  substituters:
+    - "https://merlin.cachix.org"
+  trusted_public_keys:
+    - "no-colon-here"
+`,
+			wantErr: true,
+		},
+		{
+			name: "no nix block is fine",
+			nix:  ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeConfig(t, "name: myapp\nregion: us-east-1\n"+tt.nix)
+			_, err := loadConfig()
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_NixpkgsPinValidation(t *testing.T) {
+	const validSHA = "0d843eedba88d22a7eaa2a7e54a2c1d8c0c0d4f8"
+	const validHash = "sha256-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef="
+	tests := []struct {
+		name    string
+		nix     string
+		wantErr bool
+	}{
+		{
+			name: "both fields set with valid values",
+			nix: `nix:
+  nixpkgs_rev:  "` + validSHA + `"
+  nixpkgs_hash: "` + validHash + `"
+`,
+		},
+		{
+			name: "rev without hash",
+			nix: `nix:
+  nixpkgs_rev: "` + validSHA + `"
+`,
+			wantErr: true,
+		},
+		{
+			name: "hash without rev",
+			nix: `nix:
+  nixpkgs_hash: "` + validHash + `"
+`,
+			wantErr: true,
+		},
+		{
+			name: "short rev rejected",
+			nix: `nix:
+  nixpkgs_rev:  "deadbeef"
+  nixpkgs_hash: "` + validHash + `"
+`,
+			wantErr: true,
+		},
+		{
+			name: "uppercase rev rejected",
+			nix: `nix:
+  nixpkgs_rev:  "0D843EEDBA88D22A7EAA2A7E54A2C1D8C0C0D4F8"
+  nixpkgs_hash: "` + validHash + `"
+`,
+			wantErr: true,
+		},
+		{
+			name: "hash missing sha256- prefix",
+			nix: `nix:
+  nixpkgs_rev:  "` + validSHA + `"
+  nixpkgs_hash: "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef="
+`,
+			wantErr: true,
+		},
+		{
+			name: "no pin set is fine",
+			nix:  ``,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeConfig(t, "name: myapp\nregion: us-east-1\n"+tt.nix)
+			_, err := loadConfig()
+			if tt.wantErr && err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error for %s: %v", tt.name, err)
+			}
+		})
+	}
+}
+
+func TestCachixCacheName(t *testing.T) {
+	tests := []struct {
+		url  string
+		want string
+	}{
+		{"https://merlin.cachix.org", "merlin"},
+		{"https://my-project.cachix.org", "my-project"},
+		{"https://acme123.cachix.org", "acme123"},
+		{"http://merlin.cachix.org", ""},
+		{"https://cache.s3.amazonaws.com", ""},
+		{"https://merlin.cachix.org/path", ""},
+		{"not a url", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.url, func(t *testing.T) {
+			if got := CachixCacheName(tt.url); got != tt.want {
+				t.Errorf("CachixCacheName(%q) = %q, want %q", tt.url, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_VendorValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr bool
+	}{
+		{
+			name: "rust with vendor: true and empty hash is ok",
+			body: `
+app:
+  language: rust
+  vendor: true
+  nix_vendor_hash: ""
+`,
+		},
+		{
+			name: "go with vendor: true and empty hash is ok",
+			body: `
+app:
+  language: go
+  vendor: true
+  nix_vendor_hash: ""
+`,
+		},
+		{
+			name: "nodejs with vendor: true is rejected",
+			body: `
+app:
+  language: nodejs
+  vendor: true
+`,
+			wantErr: true,
+		},
+		{
+			name: "dotnet with vendor: true is rejected",
+			body: `
+app:
+  language: dotnet
+  vendor: true
+`,
+			wantErr: true,
+		},
+		{
+			name: "rust with vendor: true and non-empty hash is rejected (mutex)",
+			body: `
+app:
+  language: rust
+  vendor: true
+  nix_vendor_hash: "sha256-abc="
+`,
+			wantErr: true,
+		},
+		{
+			name: "vendor omitted defaults to false (no validation triggered)",
+			body: `
+app:
+  language: rust
+  nix_vendor_hash: "sha256-abc="
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeConfig(t, "name: myapp\nregion: us-east-1\n"+tt.body)
+			cfg, err := loadConfig()
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %s, got nil", tt.name)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error for %s: %v", tt.name, err)
+				return
+			}
+			// Round-trip sanity: vendor bool reaches cfg.App.Vendor
+			if cfg == nil {
+				t.Fatal("nil config")
+			}
+		})
+	}
+}
+
+func TestLoadConfig_VendorDefaultFalse(t *testing.T) {
+	writeConfig(t, `
+name: myapp
+region: us-east-1
+app:
+  language: go
+`)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if cfg.App.Vendor {
+		t.Errorf("App.Vendor = true, want false (default when unset)")
+	}
+}
+
+func TestLoadConfig_VendorTrueRoundTrips(t *testing.T) {
+	writeConfig(t, `
+name: myapp
+region: us-east-1
+app:
+  language: rust
+  vendor: true
+`)
+	cfg, err := loadConfig()
+	if err != nil {
+		t.Fatalf("loadConfig: %v", err)
+	}
+	if !cfg.App.Vendor {
+		t.Errorf("App.Vendor = false, want true")
+	}
+}
+
 func TestLoadConfig_TLSValidation(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cli/config_test.go
+++ b/cli/config_test.go
@@ -434,7 +434,8 @@ func TestLoadConfig_NixCacheValidation(t *testing.T) {
 
 func TestLoadConfig_NixpkgsPinValidation(t *testing.T) {
 	const validSHA = "0d843eedba88d22a7eaa2a7e54a2c1d8c0c0d4f8"
-	const validHash = "sha256-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef="
+	// SRI sha256 of the empty string (43 base64 chars + "=") — real, valid.
+	const validHash = "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
 	tests := []struct {
 		name    string
 		nix     string
@@ -482,6 +483,30 @@ func TestLoadConfig_NixpkgsPinValidation(t *testing.T) {
 			nix: `nix:
   nixpkgs_rev:  "` + validSHA + `"
   nixpkgs_hash: "aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef="
+`,
+			wantErr: true,
+		},
+		{
+			name: "hash with sha256- prefix but garbage body rejected",
+			nix: `nix:
+  nixpkgs_rev:  "` + validSHA + `"
+  nixpkgs_hash: "sha256-!!!"
+`,
+			wantErr: true,
+		},
+		{
+			name: "hash too short rejected",
+			nix: `nix:
+  nixpkgs_rev:  "` + validSHA + `"
+  nixpkgs_hash: "sha256-aBc="
+`,
+			wantErr: true,
+		},
+		{
+			name: "hash missing trailing = rejected",
+			nix: `nix:
+  nixpkgs_rev:  "` + validSHA + `"
+  nixpkgs_hash: "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU"
 `,
 			wantErr: true,
 		},

--- a/cli/framework_files.go
+++ b/cli/framework_files.go
@@ -1,12 +1,55 @@
 package cli
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // frameworkFile describes a template file to scaffold during `enclave init`.
 type frameworkFile struct {
 	RelPath string      // path relative to user's project root
 	Mode    os.FileMode // file permissions
 	Content string      // file content
+}
+
+// Placeholders replaced in flake templates at scaffold time.
+const (
+	nixpkgsRefPlaceholder       = "{{NixpkgsRef}}"
+	flakeUtilsRefPlaceholder    = "{{FlakeUtilsRef}}"
+	awsNitroUtilRefPlaceholder  = "{{AwsNitroUtilRef}}"
+)
+
+// DefaultNixpkgsRef is the nixpkgs reference baked into scaffolded flakes
+// when the operator hasn't set nix.nixpkgs_rev in enclave.yaml. A branch
+// reference — same behavior as before this feature existed — so opting in
+// to reproducibility is an explicit `enclave nixpkgs pin --latest` step,
+// not something the framework silently does on the operator's behalf.
+const DefaultNixpkgsRef = "nixos-25.11"
+
+// Framework-managed flake inputs. Unlike nixpkgs (which the operator pins
+// for reproducibility of their own derivation graph), these are framework
+// infrastructure — operators don't touch them. Bumping is a framework-release
+// activity. Pinned to commit SHAs so the derivation graph is fully closed.
+const (
+	// flake-utils @ main, fetched 2026-06-01.
+	FlakeUtilsRef = "11707dc2f618dd54ca8739b309ec4fc024de578b"
+	// aws-nitro-util @ master, fetched 2026-06-01.
+	AwsNitroUtilRef = "b529ed6299a49ebe362d3cf618b21d6dac4a2e48"
+)
+
+// applyNixpkgsRef substitutes flake input references into a template.
+// Replaces {{NixpkgsRef}} with the operator's pin (or DefaultNixpkgsRef
+// when empty), and {{FlakeUtilsRef}} / {{AwsNitroUtilRef}} with the
+// framework-managed commit pins. Kept as a single helper because all three
+// substitutions happen together at every scaffold call site.
+func applyNixpkgsRef(template, nixpkgsRef string) string {
+	if nixpkgsRef == "" {
+		nixpkgsRef = DefaultNixpkgsRef
+	}
+	out := strings.ReplaceAll(template, nixpkgsRefPlaceholder, nixpkgsRef)
+	out = strings.ReplaceAll(out, flakeUtilsRefPlaceholder, FlakeUtilsRef)
+	out = strings.ReplaceAll(out, awsNitroUtilRefPlaceholder, AwsNitroUtilRef)
+	return out
 }
 
 // getInitFiles returns the build-time framework files scaffolded by
@@ -18,6 +61,13 @@ type frameworkFile struct {
 // via getTofuFiles; splitting the two lets users customize one without
 // inadvertently regenerating the other.
 func getInitFiles(language string) []frameworkFile {
+	return getInitFilesWithNixpkgs(language, "")
+}
+
+// getInitFilesWithNixpkgs is the same as getInitFiles but substitutes the
+// given nixpkgs reference into the flake template. Empty ref uses
+// DefaultNixpkgsRef.
+func getInitFilesWithNixpkgs(language, nixpkgsRef string) []frameworkFile {
 	flakeNix := frameworkFlakeNix // default: Go
 	switch language {
 	case "nodejs":
@@ -32,7 +82,7 @@ func getInitFiles(language string) []frameworkFile {
 		{
 			RelPath: "enclave/flake.nix",
 			Mode:    0644,
-			Content: flakeNix,
+			Content: applyNixpkgsRef(flakeNix, nixpkgsRef),
 		},
 		{
 			RelPath: ".github/workflows/deploy-enclave.yml",
@@ -203,9 +253,12 @@ const frameworkFlakeNix = `{
   description = "Nitro Enclave - reproducible build";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    flake-utils.url = "github:numtide/flake-utils";
-    aws-nitro-util.url = "github:monzo/aws-nitro-util";
+    nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";
+    flake-utils.url = "github:numtide/flake-utils/{{FlakeUtilsRef}}";
+    flake-utils.inputs.systems.follows = "";
+    aws-nitro-util.url = "github:monzo/aws-nitro-util/{{AwsNitroUtilRef}}";
+    aws-nitro-util.inputs.nixpkgs.follows = "nixpkgs";
+    aws-nitro-util.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils, aws-nitro-util }:
@@ -261,6 +314,8 @@ const frameworkFlakeNix = `{
         };
 
         # User's app — fetched from GitHub. No runtime dependency needed.
+        # vendor: true → use the committed vendor/ in the source tree (offline-safe);
+        # otherwise use vendorHash to fetch deps via go mod download.
         upstream-app = eifPkgs.buildGoModule ({
           pname = appCfg.binary_name;
           version = buildCfg.version;
@@ -272,8 +327,10 @@ const frameworkFlakeNix = `{
             hash = appCfg.nix_hash;
           };
 
-          vendorHash = if appCfg.nix_vendor_hash == "" then null else appCfg.nix_vendor_hash;
-          proxyVendor = true;
+          vendorHash = if (appCfg.vendor or false) then null
+                       else if appCfg.nix_vendor_hash == "" then null
+                       else appCfg.nix_vendor_hash;
+          proxyVendor = !(appCfg.vendor or false);
 
           subPackages = appCfg.nix_sub_packages;
           env.CGO_ENABLED = "0";
@@ -356,26 +413,29 @@ const frameworkFlakeNix = `{
         };
 
         # Vendor hash check — used by enclave setup to discover the correct hash.
-        vendor-hash-check = eifPkgs.buildGoModule ({
-          pname = "vendor-hash-check";
-          version = buildCfg.version;
-          src = eifPkgs.fetchFromGitHub {
-            owner = appCfg.nix_owner;
-            repo = appCfg.nix_repo;
-            rev = appCfg.nix_rev;
-            hash = appCfg.nix_hash;
-          };
-          vendorHash = "";
-          proxyVendor = true;
-          subPackages = appCfg.nix_sub_packages;
-          env.CGO_ENABLED = "0";
-          doCheck = false;
+        # No-op in vendor mode (nothing to discover — vendor/ is committed).
+        vendor-hash-check = if (appCfg.vendor or false)
+          then eifPkgs.runCommand "vendor-hash-check-noop" {} "echo noop > $out"
+          else eifPkgs.buildGoModule ({
+            pname = "vendor-hash-check";
+            version = buildCfg.version;
+            src = eifPkgs.fetchFromGitHub {
+              owner = appCfg.nix_owner;
+              repo = appCfg.nix_repo;
+              rev = appCfg.nix_rev;
+              hash = appCfg.nix_hash;
+            };
+            vendorHash = "";
+            proxyVendor = true;
+            subPackages = appCfg.nix_sub_packages;
+            env.CGO_ENABLED = "0";
+            doCheck = false;
 
-          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
-          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
-        } // (if (appCfg.nix_subdir or "") != "" then {
-          sourceRoot = "source/` + "${appCfg.nix_subdir}" + `";
-        } else {}));
+            nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+            buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
+          } // (if (appCfg.nix_subdir or "") != "" then {
+            sourceRoot = "source/` + "${appCfg.nix_subdir}" + `";
+          } else {}));
 
       in
       {
@@ -393,9 +453,12 @@ const frameworkFlakeNixNodejs = `{
   description = "Nitro Enclave - reproducible build (Node.js)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    flake-utils.url = "github:numtide/flake-utils";
-    aws-nitro-util.url = "github:monzo/aws-nitro-util";
+    nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";
+    flake-utils.url = "github:numtide/flake-utils/{{FlakeUtilsRef}}";
+    flake-utils.inputs.systems.follows = "";
+    aws-nitro-util.url = "github:monzo/aws-nitro-util/{{AwsNitroUtilRef}}";
+    aws-nitro-util.inputs.nixpkgs.follows = "nixpkgs";
+    aws-nitro-util.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils, aws-nitro-util }:
@@ -622,6 +685,17 @@ jobs:
 
       - name: Pull Nix Docker image
         run: docker pull nixos/nix:2.24.9
+
+      # Wire up the Cachix binary cache when configured. Pulls cached store
+      # paths before the build and pushes any newly-built paths at job end.
+      # Opt in by setting vars.CACHIX_CACHE_NAME + secrets.CACHIX_AUTH_TOKEN.
+      # If unset, the step is skipped and the build runs without the cache.
+      - name: Setup Cachix
+        if: vars.CACHIX_CACHE_NAME != ''
+        uses: cachix/cachix-action@v15
+        with:
+          name: ` + "${{ vars.CACHIX_CACHE_NAME }}" + `
+          authToken: ` + "${{ secrets.CACHIX_AUTH_TOKEN }}" + `
 
       - name: Build and deploy
         id: deploy
@@ -902,10 +976,13 @@ const frameworkFlakeNixDotnet = `{
 
   inputs = {
     # Pinned nixpkgs commit for reproducible .NET SDK version.
-    # Update deliberately with: nix flake update nixpkgs
-    nixpkgs.url = "github:NixOS/nixpkgs/e38213b91d3786389a446dfce4ff5a8aaf6012f2";
-    flake-utils.url = "github:numtide/flake-utils";
-    aws-nitro-util.url = "github:monzo/aws-nitro-util";
+    # Update deliberately with: enclave nixpkgs pin --latest
+    nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";
+    flake-utils.url = "github:numtide/flake-utils/{{FlakeUtilsRef}}";
+    flake-utils.inputs.systems.follows = "";
+    aws-nitro-util.url = "github:monzo/aws-nitro-util/{{AwsNitroUtilRef}}";
+    aws-nitro-util.inputs.nixpkgs.follows = "nixpkgs";
+    aws-nitro-util.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils, aws-nitro-util }:
@@ -1082,9 +1159,12 @@ const frameworkFlakeNixRust = `{
   description = "Nitro Enclave - reproducible build (Rust)";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
-    flake-utils.url = "github:numtide/flake-utils";
-    aws-nitro-util.url = "github:monzo/aws-nitro-util";
+    nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";
+    flake-utils.url = "github:numtide/flake-utils/{{FlakeUtilsRef}}";
+    flake-utils.inputs.systems.follows = "";
+    aws-nitro-util.url = "github:monzo/aws-nitro-util/{{AwsNitroUtilRef}}";
+    aws-nitro-util.inputs.nixpkgs.follows = "nixpkgs";
+    aws-nitro-util.inputs.flake-utils.follows = "flake-utils";
   };
 
   outputs = { self, nixpkgs, flake-utils, aws-nitro-util }:
@@ -1134,6 +1214,8 @@ const frameworkFlakeNixRust = `{
         };
 
         # User's Rust app — fetched from GitHub. No runtime dependency needed.
+        # vendor: true → use the committed vendor/ in the source tree (offline-safe);
+        # otherwise use cargoHash to fetch crates via fetchCargoVendor.
         upstream-app = eifPkgs.rustPlatform.buildRustPackage ({
           pname = appCfg.binary_name;
           version = buildCfg.version;
@@ -1144,8 +1226,6 @@ const frameworkFlakeNixRust = `{
             rev = appCfg.nix_rev;
             hash = appCfg.nix_hash;
           };
-
-          cargoHash = if appCfg.nix_vendor_hash == "" then "" else appCfg.nix_vendor_hash;
 
           doCheck = false;
 
@@ -1160,7 +1240,11 @@ const frameworkFlakeNixRust = `{
               fi
             done
           '';
-        } // (if (appCfg.nix_subdir or "") != "" then {
+        }
+        // (if (appCfg.vendor or false)
+             then { cargoVendorDir = "vendor"; }
+             else { cargoHash = if appCfg.nix_vendor_hash == "" then "" else appCfg.nix_vendor_hash; })
+        // (if (appCfg.nix_subdir or "") != "" then {
           sourceRoot = "source";
           cargoRoot = appCfg.nix_subdir;
           buildAndTestSubdir = appCfg.nix_subdir;
@@ -1219,25 +1303,28 @@ const frameworkFlakeNixRust = `{
         };
 
         # Vendor hash check — used by enclave setup to discover the correct hash.
-        vendor-hash-check = eifPkgs.rustPlatform.buildRustPackage ({
-          pname = "vendor-hash-check";
-          version = buildCfg.version;
-          src = eifPkgs.fetchFromGitHub {
-            owner = appCfg.nix_owner;
-            repo = appCfg.nix_repo;
-            rev = appCfg.nix_rev;
-            hash = appCfg.nix_hash;
-          };
-          cargoHash = "";
-          doCheck = false;
+        # No-op in vendor mode (nothing to discover — vendor/ is committed).
+        vendor-hash-check = if (appCfg.vendor or false)
+          then eifPkgs.runCommand "vendor-hash-check-noop" {} "echo noop > $out"
+          else eifPkgs.rustPlatform.buildRustPackage ({
+            pname = "vendor-hash-check";
+            version = buildCfg.version;
+            src = eifPkgs.fetchFromGitHub {
+              owner = appCfg.nix_owner;
+              repo = appCfg.nix_repo;
+              rev = appCfg.nix_rev;
+              hash = appCfg.nix_hash;
+            };
+            cargoHash = "";
+            doCheck = false;
 
-          nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
-          buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
-        } // (if (appCfg.nix_subdir or "") != "" then {
-          sourceRoot = "source";
-          cargoRoot = appCfg.nix_subdir;
-          buildAndTestSubdir = appCfg.nix_subdir;
-        } else {}));
+            nativeBuildInputs = resolveInputs (appCfg.nix_native_build_inputs or []);
+            buildInputs = resolveInputs (appCfg.nix_build_inputs or []);
+          } // (if (appCfg.nix_subdir or "") != "" then {
+            sourceRoot = "source";
+            cargoRoot = appCfg.nix_subdir;
+            buildAndTestSubdir = appCfg.nix_subdir;
+          } else {}));
 
       in
       {
@@ -1458,6 +1545,17 @@ jobs:
 
       - name: Pull Nix Docker image
         run: docker pull nixos/nix:2.24.9
+
+      # Wire up the Cachix binary cache when configured. Pulls cached store
+      # paths before the build and pushes any newly-built paths at job end.
+      # Opt in by setting vars.CACHIX_CACHE_NAME + secrets.CACHIX_AUTH_TOKEN.
+      # If unset, the step is skipped and the build runs without the cache.
+      - name: Setup Cachix
+        if: vars.CACHIX_CACHE_NAME != ''
+        uses: cachix/cachix-action@v15
+        with:
+          name: ` + "${{ vars.CACHIX_CACHE_NAME }}" + `
+          authToken: ` + "${{ secrets.CACHIX_AUTH_TOKEN }}" + `
 
       - name: Build EIF
         run: enclave build

--- a/cli/framework_files.go
+++ b/cli/framework_files.go
@@ -19,12 +19,14 @@ const (
 	awsNitroUtilRefPlaceholder  = "{{AwsNitroUtilRef}}"
 )
 
-// DefaultNixpkgsRef is the nixpkgs reference baked into scaffolded flakes
-// when the operator hasn't set nix.nixpkgs_rev in enclave.yaml. A branch
-// reference — same behavior as before this feature existed — so opting in
-// to reproducibility is an explicit `enclave nixpkgs pin --latest` step,
-// not something the framework silently does on the operator's behalf.
-const DefaultNixpkgsRef = "nixos-25.11"
+// DefaultNixpkgsRef is the nixpkgs commit baked into scaffolded flakes when
+// the operator hasn't set nix.nixpkgs_rev in enclave.yaml. Pinned per
+// framework release (same pattern as FlakeUtilsRef / AwsNitroUtilRef) so
+// new projects are reproducible by default. Operators who want a different
+// commit run `enclave nixpkgs pin` to override.
+//
+// nixpkgs @ nixos-25.11 tip, fetched 2026-06-03.
+const DefaultNixpkgsRef = "25f538306313eae3927264466c70d7001dcea1df"
 
 // Framework-managed flake inputs. Unlike nixpkgs (which the operator pins
 // for reproducibility of their own derivation graph), these are framework
@@ -976,7 +978,7 @@ const frameworkFlakeNixDotnet = `{
 
   inputs = {
     # Pinned nixpkgs commit for reproducible .NET SDK version.
-    # Update deliberately with: enclave nixpkgs pin --latest
+    # Update deliberately with: enclave nixpkgs pin
     nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";
     flake-utils.url = "github:numtide/flake-utils/{{FlakeUtilsRef}}";
     flake-utils.inputs.systems.follows = "";

--- a/cli/init.go
+++ b/cli/init.go
@@ -47,6 +47,15 @@ app:
   nix_subdir: ""                 # Subdirectory for monorepo (e.g. "server")
   binary_name: ""                # Output binary name (defaults to 'name')
   release_tag: "eif-latest"      # GitHub Release tag used by 'enclave tofu init --remote'
+  vendor: false                  # (go|rust only) Set true after committing vendor/ to the app repo
+                                 # (cargo vendor / go mod vendor). Offline builds survive upstream
+                                 # dep disappearance regardless of cache state. Workflow:
+                                 # 1) run 'enclave vendor --path <app-repo>' to populate vendor/
+                                 # 2) git add vendor/ && commit && push
+                                 # 3) flip vendor: true here AND clear nix_vendor_hash
+                                 # 4) 'enclave setup' (sees vendor: true, skips hash discovery)
+                                 # Note: step 3 BEFORE step 4 — setup's trial build needs upstream
+                                 # otherwise, which defeats the recovery purpose.
 
   # Optional build-time env values baked into the EIF (each value
   # contributes to PCR0). Use ONLY when you need a value cryptographically
@@ -86,6 +95,27 @@ tls:
   fqdn: ""
   email: ""
   route53_zone_id: ""
+
+# Nix binary cache + reproducibility settings (optional).
+#
+# Without these, the EIF still builds — but every rebuild has to fetch every
+# transitive dep from upstream. If a Cargo crate moves or a GitHub repo gets
+# renamed, enclave build breaks.
+#
+# Cachix (https://cachix.org) hosts a project-specific binary cache so future
+# builds resolve from the cache instead of upstream. nixpkgs_rev pins the
+# flake's nixpkgs input to a commit so the derivation graph is stable.
+#
+# Bump the pin with: enclave nixpkgs pin --latest
+# Push the closure after a build with: enclave build --push-cache
+#
+# nix:
+#   substituters:
+#     - "https://myproject.cachix.org"   # only Cachix URLs are accepted
+#   trusted_public_keys:
+#     - "myproject.cachix.org-1:<base64-key>="
+#   nixpkgs_rev:  ""                     # 40-char commit SHA
+#   nixpkgs_hash: ""                     # sha256-<SRI hash>
 `
 
 func initCmd() *cobra.Command {

--- a/cli/init.go
+++ b/cli/init.go
@@ -106,7 +106,7 @@ tls:
 # builds resolve from the cache instead of upstream. nixpkgs_rev pins the
 # flake's nixpkgs input to a commit so the derivation graph is stable.
 #
-# Bump the pin with: enclave nixpkgs pin --latest
+# Bump the pin with: enclave nixpkgs pin
 # Push the closure after a build with: enclave build --push-cache
 #
 # nix:

--- a/cli/main.go
+++ b/cli/main.go
@@ -36,6 +36,8 @@ func Execute() {
 		traceCmd(),
 		metricsCmd(),
 		migrationStatusCmd(),
+		nixpkgsCmd(),
+		vendorCmd(),
 		testCmd(),
 	)
 

--- a/cli/nixpkgs_cmd.go
+++ b/cli/nixpkgs_cmd.go
@@ -67,7 +67,7 @@ func nixpkgsPinCmd() *cobra.Command {
 
 func runPinCheck(cfg *Config) error {
 	if cfg.Nix.NixpkgsRev == "" {
-		return fmt.Errorf("no pin set — nix.nixpkgs_rev is empty in enclave.yaml. Run `enclave nixpkgs pin --latest` to create one.")
+		return fmt.Errorf("no pin set — nix.nixpkgs_rev is empty in enclave.yaml (run `enclave nixpkgs pin --latest` to create one)")
 	}
 	if !commitSHARegex.MatchString(cfg.Nix.NixpkgsRev) {
 		return fmt.Errorf("nix.nixpkgs_rev %q is not a 40-char hex commit SHA", cfg.Nix.NixpkgsRev)
@@ -175,7 +175,7 @@ func prefetchNixpkgsHashOverHTTP(url string) (string, error) {
 	if _, err := io.Copy(h, resp.Body); err != nil {
 		return "", fmt.Errorf("read tarball: %w", err)
 	}
-	return "", fmt.Errorf("`nix-prefetch-url` not on PATH — install Nix (https://nixos.org/download) to compute the SRI hash. Tarball downloaded OK (%d bytes) but the hash of the gzipped bytes is not what Nix wants.", h.Size())
+	return "", fmt.Errorf("`nix-prefetch-url` not on PATH — install Nix (https://nixos.org/download) to compute the SRI hash (tarball downloaded OK at %d bytes but the gzipped-byte hash is not what Nix wants)", h.Size())
 }
 
 // nixHashToSRI converts a `nix-prefetch-url` (legacy base32) or already-SRI

--- a/cli/nixpkgs_cmd.go
+++ b/cli/nixpkgs_cmd.go
@@ -1,11 +1,8 @@
 package cli
 
 import (
-	"crypto/sha256"
 	"encoding/base64"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -72,8 +69,8 @@ func runPinCheck(cfg *Config) error {
 	if !commitSHARegex.MatchString(cfg.Nix.NixpkgsRev) {
 		return fmt.Errorf("nix.nixpkgs_rev %q is not a 40-char hex commit SHA", cfg.Nix.NixpkgsRev)
 	}
-	if !strings.HasPrefix(cfg.Nix.NixpkgsHash, "sha256-") {
-		return fmt.Errorf("nix.nixpkgs_hash %q must start with 'sha256-' (SRI format)", cfg.Nix.NixpkgsHash)
+	if !sriSha256Regex.MatchString(cfg.Nix.NixpkgsHash) {
+		return fmt.Errorf("nix.nixpkgs_hash %q must be SRI-formatted sha256 ('sha256-' + 43 base64 chars + '=')", cfg.Nix.NixpkgsHash)
 	}
 	fmt.Printf("nixpkgs pin OK: %s (%s)\n", cfg.Nix.NixpkgsRev, cfg.Nix.NixpkgsHash)
 	return nil
@@ -142,40 +139,20 @@ func gitLsRemoteBranch(repoURL, branch string) (string, error) {
 // and returns the SRI hash of the unpacked contents. Uses `nix-prefetch-url
 // --unpack` so the hash matches what fetchTarball produces in the flake.
 func prefetchNixpkgsHash(rev string) (string, error) {
+	if _, err := exec.LookPath("nix-prefetch-url"); err != nil {
+		return "", fmt.Errorf("`nix-prefetch-url` not on PATH — install Nix (https://nixos.org/download) to compute the SRI hash")
+	}
 	url := fmt.Sprintf("https://github.com/NixOS/nixpkgs/archive/%s.tar.gz", rev)
-	if _, err := exec.LookPath("nix-prefetch-url"); err == nil {
-		out, err := exec.Command("nix-prefetch-url", "--unpack", "--type", "sha256", url).Output()
-		if err != nil {
-			return "", fmt.Errorf("nix-prefetch-url %s: %w (is Nix installed?)", url, err)
-		}
-		raw := strings.TrimSpace(string(out))
-		sri, err := nixHashToSRI(raw)
-		if err != nil {
-			return "", fmt.Errorf("convert nix-prefetch-url output to SRI: %w", err)
-		}
-		return sri, nil
-	}
-	return prefetchNixpkgsHashOverHTTP(url)
-}
-
-// prefetchNixpkgsHashOverHTTP downloads the tarball and computes the SRI
-// hash directly. Slower than nix-prefetch-url (no caching) and only matches
-// the unpacked-tree hash if used with `fetchTarball` style fetchers; flake
-// inputs use a different hashing scheme. Kept as a fallback for hint only.
-func prefetchNixpkgsHashOverHTTP(url string) (string, error) {
-	resp, err := http.Get(url)
+	out, err := exec.Command("nix-prefetch-url", "--unpack", "--type", "sha256", url).Output()
 	if err != nil {
-		return "", fmt.Errorf("http get %s: %w", url, err)
+		return "", fmt.Errorf("nix-prefetch-url %s: %w (is Nix installed?)", url, err)
 	}
-	defer func() { _ = resp.Body.Close() }()
-	if resp.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("http get %s: %s", url, resp.Status)
+	raw := strings.TrimSpace(string(out))
+	sri, err := nixHashToSRI(raw)
+	if err != nil {
+		return "", fmt.Errorf("convert nix-prefetch-url output to SRI: %w", err)
 	}
-	h := sha256.New()
-	if _, err := io.Copy(h, resp.Body); err != nil {
-		return "", fmt.Errorf("read tarball: %w", err)
-	}
-	return "", fmt.Errorf("`nix-prefetch-url` not on PATH — install Nix (https://nixos.org/download) to compute the SRI hash (tarball downloaded OK at %d bytes but the gzipped-byte hash is not what Nix wants)", h.Size())
+	return sri, nil
 }
 
 // nixHashToSRI converts a `nix-prefetch-url` (legacy base32) or already-SRI
@@ -231,8 +208,10 @@ func decodeNixBase32(s string) ([]byte, error) {
 
 var (
 	nixpkgsURLRegex = regexp.MustCompile(`(github:NixOS/nixpkgs/)[^"]+`)
-	nixpkgsRevYamlRegex  = regexp.MustCompile(`(?m)^(\s*nixpkgs_rev:\s*).*$`)
-	nixpkgsHashYamlRegex = regexp.MustCompile(`(?m)^(\s*nixpkgs_hash:\s*).*$`)
+	// Anchored to the canonical 2-space indent under `nix:` so unrelated
+	// fields elsewhere in the yaml can't accidentally match.
+	nixpkgsRevYamlRegex  = regexp.MustCompile(`(?m)^(  nixpkgs_rev:\s*).*$`)
+	nixpkgsHashYamlRegex = regexp.MustCompile(`(?m)^(  nixpkgs_hash:\s*).*$`)
 	nixBlockYamlRegex    = regexp.MustCompile(`(?m)^nix:\s*$`)
 )
 

--- a/cli/nixpkgs_cmd.go
+++ b/cli/nixpkgs_cmd.go
@@ -1,0 +1,291 @@
+package cli
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const defaultNixpkgsBranch = "nixos-25.11"
+
+func nixpkgsCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "nixpkgs",
+		Short: "Manage the pinned nixpkgs commit for reproducible builds",
+		Long: `Pin the nixpkgs revision used by the flake template to a specific commit.
+
+A pinned commit guarantees the derivation graph is byte-identical across
+builds — so the EIF stays reproducible even when the nixpkgs branch tip
+moves upstream (security patches, package updates).
+
+Use 'enclave nixpkgs pin --latest' to fetch the current branch tip and
+write it to enclave.yaml + enclave/flake.nix. Use 'enclave nixpkgs pin --check'
+to validate the existing pin without bumping it.`,
+	}
+	cmd.AddCommand(nixpkgsPinCmd())
+	return cmd
+}
+
+func nixpkgsPinCmd() *cobra.Command {
+	var latest bool
+	var checkOnly bool
+	var branch string
+	cmd := &cobra.Command{
+		Use:   "pin",
+		Short: "Pin nixpkgs to a specific commit for byte-identical EIFs",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if !latest && !checkOnly {
+				return fmt.Errorf("specify one of --latest or --check")
+			}
+			if latest && checkOnly {
+				return fmt.Errorf("--latest and --check are mutually exclusive")
+			}
+			cfg, err := loadConfig()
+			if err != nil {
+				return err
+			}
+			if checkOnly {
+				return runPinCheck(cfg)
+			}
+			return runPinLatest(branch)
+		},
+	}
+	cmd.Flags().BoolVar(&latest, "latest", false, "Fetch the latest commit from --branch and pin to it (writes enclave.yaml + enclave/flake.nix)")
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Validate the existing pin without bumping (no network)")
+	cmd.Flags().StringVar(&branch, "branch", defaultNixpkgsBranch, "nixpkgs branch to follow when --latest is set")
+	return cmd
+}
+
+func runPinCheck(cfg *Config) error {
+	if cfg.Nix.NixpkgsRev == "" {
+		return fmt.Errorf("no pin set — nix.nixpkgs_rev is empty in enclave.yaml. Run `enclave nixpkgs pin --latest` to create one.")
+	}
+	if !commitSHARegex.MatchString(cfg.Nix.NixpkgsRev) {
+		return fmt.Errorf("nix.nixpkgs_rev %q is not a 40-char hex commit SHA", cfg.Nix.NixpkgsRev)
+	}
+	if !strings.HasPrefix(cfg.Nix.NixpkgsHash, "sha256-") {
+		return fmt.Errorf("nix.nixpkgs_hash %q must start with 'sha256-' (SRI format)", cfg.Nix.NixpkgsHash)
+	}
+	fmt.Printf("nixpkgs pin OK: %s (%s)\n", cfg.Nix.NixpkgsRev, cfg.Nix.NixpkgsHash)
+	return nil
+}
+
+func runPinLatest(branch string) error {
+	root, err := findRepoRoot()
+	if err != nil {
+		return err
+	}
+	cfgPath := resolveConfigPath(root)
+
+	fmt.Printf("[pin] Fetching tip of %s from github.com/NixOS/nixpkgs...\n", branch)
+	rev, err := gitLsRemoteBranch("https://github.com/NixOS/nixpkgs.git", branch)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("[pin] Tip is %s\n", rev)
+
+	fmt.Printf("[pin] Computing SRI hash of the tarball (may take a minute)...\n")
+	hash, err := prefetchNixpkgsHash(rev)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("[pin] Hash is %s\n", hash)
+
+	if err := updateNixpkgsInYaml(cfgPath, rev, hash); err != nil {
+		return fmt.Errorf("update %s: %w", cfgPath, err)
+	}
+	flakePath := filepath.Join(filepath.Dir(cfgPath), "flake.nix")
+	if _, err := os.Stat(flakePath); err == nil {
+		if err := updateNixpkgsInFlake(flakePath, rev); err != nil {
+			return fmt.Errorf("update %s: %w", flakePath, err)
+		}
+		fmt.Printf("[pin] Updated %s\n", flakePath)
+	}
+
+	fmt.Printf("[pin] Updated %s\n", cfgPath)
+	fmt.Printf("[pin] Pinned nixpkgs to %s\n", rev)
+	return nil
+}
+
+// gitLsRemoteBranch returns the commit SHA at the tip of the given branch.
+// Shells out to `git ls-remote` since the alternative (hitting the GitHub
+// API) needs auth for high-traffic users.
+func gitLsRemoteBranch(repoURL, branch string) (string, error) {
+	if _, err := exec.LookPath("git"); err != nil {
+		return "", fmt.Errorf("`git` not found on PATH — install git to use `enclave nixpkgs pin --latest`")
+	}
+	out, err := exec.Command("git", "ls-remote", repoURL, "refs/heads/"+branch).Output()
+	if err != nil {
+		return "", fmt.Errorf("git ls-remote %s %s: %w", repoURL, branch, err)
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		return "", fmt.Errorf("branch %q not found in %s", branch, repoURL)
+	}
+	sha := strings.Fields(line)[0]
+	if !commitSHARegex.MatchString(sha) {
+		return "", fmt.Errorf("git ls-remote returned malformed SHA %q", sha)
+	}
+	return sha, nil
+}
+
+// prefetchNixpkgsHash downloads the nixpkgs tarball for the given commit
+// and returns the SRI hash of the unpacked contents. Uses `nix-prefetch-url
+// --unpack` so the hash matches what fetchTarball produces in the flake.
+func prefetchNixpkgsHash(rev string) (string, error) {
+	url := fmt.Sprintf("https://github.com/NixOS/nixpkgs/archive/%s.tar.gz", rev)
+	if _, err := exec.LookPath("nix-prefetch-url"); err == nil {
+		out, err := exec.Command("nix-prefetch-url", "--unpack", "--type", "sha256", url).Output()
+		if err != nil {
+			return "", fmt.Errorf("nix-prefetch-url %s: %w (is Nix installed?)", url, err)
+		}
+		raw := strings.TrimSpace(string(out))
+		sri, err := nixHashToSRI(raw)
+		if err != nil {
+			return "", fmt.Errorf("convert nix-prefetch-url output to SRI: %w", err)
+		}
+		return sri, nil
+	}
+	return prefetchNixpkgsHashOverHTTP(url)
+}
+
+// prefetchNixpkgsHashOverHTTP downloads the tarball and computes the SRI
+// hash directly. Slower than nix-prefetch-url (no caching) and only matches
+// the unpacked-tree hash if used with `fetchTarball` style fetchers; flake
+// inputs use a different hashing scheme. Kept as a fallback for hint only.
+func prefetchNixpkgsHashOverHTTP(url string) (string, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("http get %s: %w", url, err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("http get %s: %s", url, resp.Status)
+	}
+	h := sha256.New()
+	if _, err := io.Copy(h, resp.Body); err != nil {
+		return "", fmt.Errorf("read tarball: %w", err)
+	}
+	return "", fmt.Errorf("`nix-prefetch-url` not on PATH — install Nix (https://nixos.org/download) to compute the SRI hash. Tarball downloaded OK (%d bytes) but the hash of the gzipped bytes is not what Nix wants.", h.Size())
+}
+
+// nixHashToSRI converts a `nix-prefetch-url` (legacy base32) or already-SRI
+// hash string to the SRI form Nix expects in flake inputs.
+func nixHashToSRI(raw string) (string, error) {
+	if strings.HasPrefix(raw, "sha256-") {
+		return raw, nil
+	}
+	if _, err := exec.LookPath("nix"); err == nil {
+		out, err := exec.Command("nix", "hash", "to-sri", "--type", "sha256", raw).Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+	}
+	if _, err := exec.LookPath("nix-hash"); err == nil {
+		out, err := exec.Command("nix-hash", "--to-sri", "--type", "sha256", raw).Output()
+		if err == nil {
+			return strings.TrimSpace(string(out)), nil
+		}
+	}
+	decoded, err := decodeNixBase32(raw)
+	if err != nil {
+		return "", fmt.Errorf("hash %q is not SRI and could not be converted: %w", raw, err)
+	}
+	return "sha256-" + base64.StdEncoding.EncodeToString(decoded), nil
+}
+
+// nixBase32Alphabet is the alphabet used by Nix's legacy base32 hash encoding
+// — see nixpkgs/lib/hash.nix. Lowercase, no 'e', 'o', 't', 'u'.
+const nixBase32Alphabet = "0123456789abcdfghijklmnpqrsvwxyz"
+
+func decodeNixBase32(s string) ([]byte, error) {
+	if len(s) != 52 {
+		return nil, fmt.Errorf("expected 52-char base32 sha256 hash, got %d chars", len(s))
+	}
+	out := make([]byte, 32)
+	for n := 0; n < 52; n++ {
+		c := s[51-n]
+		idx := strings.IndexByte(nixBase32Alphabet, c)
+		if idx < 0 {
+			return nil, fmt.Errorf("invalid base32 char %q at position %d", c, 51-n)
+		}
+		b := n * 5
+		i := b / 8
+		j := b % 8
+		out[i] |= byte(idx) << j
+		if i+1 < 32 {
+			out[i+1] |= byte(idx) >> (8 - j)
+		}
+	}
+	return out, nil
+}
+
+var (
+	nixpkgsURLRegex = regexp.MustCompile(`(github:NixOS/nixpkgs/)[^"]+`)
+	nixpkgsRevYamlRegex  = regexp.MustCompile(`(?m)^(\s*nixpkgs_rev:\s*).*$`)
+	nixpkgsHashYamlRegex = regexp.MustCompile(`(?m)^(\s*nixpkgs_hash:\s*).*$`)
+	nixBlockYamlRegex    = regexp.MustCompile(`(?m)^nix:\s*$`)
+)
+
+// updateNixpkgsInYaml writes rev + hash into the nix: block of enclave.yaml.
+// If a nix: block already exists, the lines are updated in place; otherwise
+// a minimal nix: block is appended. Preserves all surrounding comments.
+func updateNixpkgsInYaml(path, rev, hash string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	content := string(data)
+
+	if !nixBlockYamlRegex.MatchString(content) {
+		if !strings.HasSuffix(content, "\n") {
+			content += "\n"
+		}
+		content += fmt.Sprintf("\nnix:\n  nixpkgs_rev:  %q\n  nixpkgs_hash: %q\n", rev, hash)
+		return os.WriteFile(path, []byte(content), 0644)
+	}
+
+	revRepl := fmt.Sprintf(`${1}%q`, rev)
+	hashRepl := fmt.Sprintf(`${1}%q`, hash)
+
+	if nixpkgsRevYamlRegex.MatchString(content) {
+		content = nixpkgsRevYamlRegex.ReplaceAllString(content, revRepl)
+	} else {
+		content = insertUnderNixBlock(content, fmt.Sprintf("  nixpkgs_rev:  %q", rev))
+	}
+	if nixpkgsHashYamlRegex.MatchString(content) {
+		content = nixpkgsHashYamlRegex.ReplaceAllString(content, hashRepl)
+	} else {
+		content = insertUnderNixBlock(content, fmt.Sprintf("  nixpkgs_hash: %q", hash))
+	}
+	return os.WriteFile(path, []byte(content), 0644)
+}
+
+// insertUnderNixBlock appends a line immediately after the `nix:` header,
+// indented to match. Caller guarantees the nix: block exists.
+func insertUnderNixBlock(content, line string) string {
+	return nixBlockYamlRegex.ReplaceAllString(content, "nix:\n"+line)
+}
+
+// updateNixpkgsInFlake rewrites the nixpkgs.url line in flake.nix to point
+// at the new commit SHA. No-op if no matching line exists.
+func updateNixpkgsInFlake(path, rev string) error {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+	updated := nixpkgsURLRegex.ReplaceAllString(string(data), "${1}"+rev)
+	if updated == string(data) {
+		return nil
+	}
+	return os.WriteFile(path, []byte(updated), 0644)
+}

--- a/cli/nixpkgs_cmd.go
+++ b/cli/nixpkgs_cmd.go
@@ -12,40 +12,38 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultNixpkgsBranch = "nixos-25.11"
+// nixpkgsBranch is the nixpkgs branch tracked by `enclave nixpkgs pin`.
+const nixpkgsBranch = "nixos-25.11"
 
 func nixpkgsCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "nixpkgs",
 		Short: "Manage the pinned nixpkgs commit for reproducible builds",
-		Long: `Pin the nixpkgs revision used by the flake template to a specific commit.
-
-A pinned commit guarantees the derivation graph is byte-identical across
-builds — so the EIF stays reproducible even when the nixpkgs branch tip
-moves upstream (security patches, package updates).
-
-Use 'enclave nixpkgs pin --latest' to fetch the current branch tip and
-write it to enclave.yaml + enclave/flake.nix. Use 'enclave nixpkgs pin --check'
-to validate the existing pin without bumping it.`,
 	}
 	cmd.AddCommand(nixpkgsPinCmd())
 	return cmd
 }
 
 func nixpkgsPinCmd() *cobra.Command {
-	var latest bool
 	var checkOnly bool
-	var branch string
 	cmd := &cobra.Command{
 		Use:   "pin",
-		Short: "Pin nixpkgs to a specific commit for byte-identical EIFs",
+		Short: "Pin nixpkgs to the current nixos-25.11 tip",
+		Long: `Fetches the current tip of nixos-25.11, computes its SRI hash via
+nix-prefetch-url, and writes both into:
+
+  enclave/enclave.yaml  →  nix.nixpkgs_rev + nix.nixpkgs_hash
+  enclave/flake.nix     →  nixpkgs.url = "github:NixOS/nixpkgs/<sha>"
+
+After running, commit both files. Subsequent builds use the pinned commit
+so the derivation graph — and therefore PCR0 — stays byte-identical until
+you deliberately bump the pin.
+
+The framework already ships a pinned SHA as its default, so this command
+is only needed when you want to upgrade to a newer nixpkgs commit.
+
+Use --check to validate the existing pin without any network access.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			if !latest && !checkOnly {
-				return fmt.Errorf("specify one of --latest or --check")
-			}
-			if latest && checkOnly {
-				return fmt.Errorf("--latest and --check are mutually exclusive")
-			}
 			cfg, err := loadConfig()
 			if err != nil {
 				return err
@@ -53,18 +51,16 @@ func nixpkgsPinCmd() *cobra.Command {
 			if checkOnly {
 				return runPinCheck(cfg)
 			}
-			return runPinLatest(branch)
+			return runPinLatest()
 		},
 	}
-	cmd.Flags().BoolVar(&latest, "latest", false, "Fetch the latest commit from --branch and pin to it (writes enclave.yaml + enclave/flake.nix)")
-	cmd.Flags().BoolVar(&checkOnly, "check", false, "Validate the existing pin without bumping (no network)")
-	cmd.Flags().StringVar(&branch, "branch", defaultNixpkgsBranch, "nixpkgs branch to follow when --latest is set")
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "Validate the existing pin without fetching (no network)")
 	return cmd
 }
 
 func runPinCheck(cfg *Config) error {
 	if cfg.Nix.NixpkgsRev == "" {
-		return fmt.Errorf("no pin set — nix.nixpkgs_rev is empty in enclave.yaml (run `enclave nixpkgs pin --latest` to create one)")
+		return fmt.Errorf("no pin set — nix.nixpkgs_rev is empty in enclave.yaml (run `enclave nixpkgs pin` to create one)")
 	}
 	if !commitSHARegex.MatchString(cfg.Nix.NixpkgsRev) {
 		return fmt.Errorf("nix.nixpkgs_rev %q is not a 40-char hex commit SHA", cfg.Nix.NixpkgsRev)
@@ -76,7 +72,8 @@ func runPinCheck(cfg *Config) error {
 	return nil
 }
 
-func runPinLatest(branch string) error {
+func runPinLatest() error {
+	branch := nixpkgsBranch
 	root, err := findRepoRoot()
 	if err != nil {
 		return err
@@ -118,7 +115,7 @@ func runPinLatest(branch string) error {
 // API) needs auth for high-traffic users.
 func gitLsRemoteBranch(repoURL, branch string) (string, error) {
 	if _, err := exec.LookPath("git"); err != nil {
-		return "", fmt.Errorf("`git` not found on PATH — install git to use `enclave nixpkgs pin --latest`")
+		return "", fmt.Errorf("`git` not found on PATH — install git to use `enclave nixpkgs pin`")
 	}
 	out, err := exec.Command("git", "ls-remote", repoURL, "refs/heads/"+branch).Output()
 	if err != nil {
@@ -236,21 +233,29 @@ func updateNixpkgsInYaml(path, rev, hash string) error {
 	revRepl := fmt.Sprintf(`${1}%q`, rev)
 	hashRepl := fmt.Sprintf(`${1}%q`, hash)
 
-	if nixpkgsRevYamlRegex.MatchString(content) {
+	hasRev := nixpkgsRevYamlRegex.MatchString(content)
+	hasHash := nixpkgsHashYamlRegex.MatchString(content)
+
+	switch {
+	case hasRev && hasHash:
 		content = nixpkgsRevYamlRegex.ReplaceAllString(content, revRepl)
-	} else {
-		content = insertUnderNixBlock(content, fmt.Sprintf("  nixpkgs_rev:  %q", rev))
-	}
-	if nixpkgsHashYamlRegex.MatchString(content) {
 		content = nixpkgsHashYamlRegex.ReplaceAllString(content, hashRepl)
-	} else {
+	case hasRev:
+		content = nixpkgsRevYamlRegex.ReplaceAllString(content, revRepl)
 		content = insertUnderNixBlock(content, fmt.Sprintf("  nixpkgs_hash: %q", hash))
+	case hasHash:
+		content = nixpkgsHashYamlRegex.ReplaceAllString(content, hashRepl)
+		content = insertUnderNixBlock(content, fmt.Sprintf("  nixpkgs_rev:  %q", rev))
+	default:
+		// Neither field exists — insert both in one replacement to avoid
+		// the double-call clobber bug (each call matches the same `nix:` line).
+		content = insertUnderNixBlock(content, fmt.Sprintf("  nixpkgs_rev:  %q\n  nixpkgs_hash: %q", rev, hash))
 	}
 	return os.WriteFile(path, []byte(content), 0644)
 }
 
-// insertUnderNixBlock appends a line immediately after the `nix:` header,
-// indented to match. Caller guarantees the nix: block exists.
+// insertUnderNixBlock inserts a line (or block of lines) immediately after
+// the `nix:` header. Caller guarantees the nix: block exists.
 func insertUnderNixBlock(content, line string) string {
 	return nixBlockYamlRegex.ReplaceAllString(content, "nix:\n"+line)
 }

--- a/cli/nixpkgs_cmd_test.go
+++ b/cli/nixpkgs_cmd_test.go
@@ -1,0 +1,321 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const (
+	testRev  = "0d843eedba88d22a7eaa2a7e54a2c1d8c0c0d4f8"
+	testHash = "sha256-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef="
+)
+
+func TestUpdateNixpkgsInYaml_AppendsBlockWhenMissing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enclave.yaml")
+	original := "name: myapp\nregion: us-east-1\n"
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateNixpkgsInYaml(path, testRev, testHash); err != nil {
+		t.Fatalf("updateNixpkgsInYaml: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	if !strings.Contains(out, "nix:") {
+		t.Errorf("expected nix: block to be appended, got:\n%s", out)
+	}
+	if !strings.Contains(out, testRev) {
+		t.Errorf("expected rev in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, testHash) {
+		t.Errorf("expected hash in output, got:\n%s", out)
+	}
+	if !strings.Contains(out, "name: myapp") {
+		t.Errorf("original content lost, got:\n%s", out)
+	}
+}
+
+func TestUpdateNixpkgsInYaml_UpdatesExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enclave.yaml")
+	original := `name: myapp
+region: us-east-1
+
+# Important comment above nix block
+nix:
+  substituters:
+    - "https://merlin.cachix.org"
+  trusted_public_keys:
+    - "merlin.cachix.org-1:abc="
+  nixpkgs_rev:  "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+  nixpkgs_hash: "sha256-OLDHASH=="
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateNixpkgsInYaml(path, testRev, testHash); err != nil {
+		t.Fatalf("updateNixpkgsInYaml: %v", err)
+	}
+
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := string(got)
+	if strings.Contains(out, "deadbeef") {
+		t.Errorf("old rev should have been replaced, got:\n%s", out)
+	}
+	if strings.Contains(out, "OLDHASH") {
+		t.Errorf("old hash should have been replaced, got:\n%s", out)
+	}
+	if !strings.Contains(out, testRev) || !strings.Contains(out, testHash) {
+		t.Errorf("new pin values missing, got:\n%s", out)
+	}
+	if !strings.Contains(out, "# Important comment above nix block") {
+		t.Errorf("comments must be preserved, got:\n%s", out)
+	}
+	if !strings.Contains(out, `- "https://merlin.cachix.org"`) {
+		t.Errorf("substituters list must be preserved, got:\n%s", out)
+	}
+}
+
+func TestUpdateNixpkgsInYaml_InsertsUnderExistingNixBlock(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "enclave.yaml")
+	// nix block exists but lacks the pin fields.
+	original := `name: myapp
+region: us-east-1
+nix:
+  substituters:
+    - "https://merlin.cachix.org"
+  trusted_public_keys:
+    - "merlin.cachix.org-1:abc="
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := updateNixpkgsInYaml(path, testRev, testHash); err != nil {
+		t.Fatalf("updateNixpkgsInYaml: %v", err)
+	}
+
+	got, _ := os.ReadFile(path)
+	out := string(got)
+	if !strings.Contains(out, testRev) || !strings.Contains(out, testHash) {
+		t.Errorf("missing pin values, got:\n%s", out)
+	}
+	if !strings.Contains(out, `- "https://merlin.cachix.org"`) {
+		t.Errorf("existing substituters dropped, got:\n%s", out)
+	}
+}
+
+func TestUpdateNixpkgsInFlake_RewritesURL(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flake.nix")
+	original := `{
+  description = "test";
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+}
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateNixpkgsInFlake(path, testRev); err != nil {
+		t.Fatalf("updateNixpkgsInFlake: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	out := string(got)
+	want := `nixpkgs.url = "github:NixOS/nixpkgs/` + testRev + `"`
+	if !strings.Contains(out, want) {
+		t.Errorf("expected URL rewritten, got:\n%s", out)
+	}
+	if strings.Contains(out, "nixos-25.11") {
+		t.Errorf("old branch ref should be gone, got:\n%s", out)
+	}
+	if !strings.Contains(out, "flake-utils") {
+		t.Errorf("other inputs must be preserved, got:\n%s", out)
+	}
+}
+
+func TestUpdateNixpkgsInFlake_NoOpIfNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flake.nix")
+	original := `{ description = "no nixpkgs here"; }
+`
+	if err := os.WriteFile(path, []byte(original), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := updateNixpkgsInFlake(path, testRev); err != nil {
+		t.Fatalf("updateNixpkgsInFlake: %v", err)
+	}
+	got, _ := os.ReadFile(path)
+	if string(got) != original {
+		t.Errorf("expected file unchanged, got:\n%s", string(got))
+	}
+}
+
+func TestApplyNixpkgsRef_UsesDefaultWhenEmpty(t *testing.T) {
+	template := `nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";`
+	out := applyNixpkgsRef(template, "")
+	if !strings.Contains(out, DefaultNixpkgsRef) {
+		t.Errorf("expected default ref to be used, got: %s", out)
+	}
+}
+
+func TestApplyNixpkgsRef_SubstitutesProvidedRef(t *testing.T) {
+	template := `nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";`
+	out := applyNixpkgsRef(template, testRev)
+	if !strings.Contains(out, testRev) {
+		t.Errorf("expected provided ref, got: %s", out)
+	}
+	if strings.Contains(out, "{{NixpkgsRef}}") {
+		t.Errorf("placeholder should be gone, got: %s", out)
+	}
+}
+
+func TestGetInitFiles_FlakeHasResolvedRefs(t *testing.T) {
+	placeholders := []string{
+		"{{NixpkgsRef}}",
+		"{{FlakeUtilsRef}}",
+		"{{AwsNitroUtilRef}}",
+	}
+	followsDecls := []string{
+		`aws-nitro-util.inputs.nixpkgs.follows = "nixpkgs"`,
+		`aws-nitro-util.inputs.flake-utils.follows = "flake-utils"`,
+		`flake-utils.inputs.systems.follows = ""`,
+	}
+	for _, lang := range []string{"go", "nodejs", "dotnet", "rust"} {
+		t.Run(lang, func(t *testing.T) {
+			files := getInitFiles(lang)
+			var flake string
+			for _, f := range files {
+				if f.RelPath == "enclave/flake.nix" {
+					flake = f.Content
+				}
+			}
+			if flake == "" {
+				t.Fatal("no flake.nix in init files")
+			}
+			for _, p := range placeholders {
+				if strings.Contains(flake, p) {
+					t.Errorf("placeholder %s leaked into scaffolded flake.nix", p)
+				}
+			}
+			if !strings.Contains(flake, DefaultNixpkgsRef) {
+				t.Errorf("expected DefaultNixpkgsRef in scaffolded flake.nix")
+			}
+			if !strings.Contains(flake, FlakeUtilsRef) {
+				t.Errorf("expected FlakeUtilsRef in scaffolded flake.nix")
+			}
+			if !strings.Contains(flake, AwsNitroUtilRef) {
+				t.Errorf("expected AwsNitroUtilRef in scaffolded flake.nix")
+			}
+			for _, decl := range followsDecls {
+				if !strings.Contains(flake, decl) {
+					t.Errorf("expected follows declaration %q in scaffolded flake.nix", decl)
+				}
+			}
+		})
+	}
+}
+
+func TestApplyNixpkgsRef_SubstitutesFrameworkPins(t *testing.T) {
+	template := `inputs = {
+  nixpkgs.url = "github:NixOS/nixpkgs/{{NixpkgsRef}}";
+  flake-utils.url = "github:numtide/flake-utils/{{FlakeUtilsRef}}";
+  aws-nitro-util.url = "github:monzo/aws-nitro-util/{{AwsNitroUtilRef}}";
+};`
+	out := applyNixpkgsRef(template, "custom-pin")
+	if !strings.Contains(out, "custom-pin") {
+		t.Errorf("nixpkgs override not applied, got: %s", out)
+	}
+	if !strings.Contains(out, FlakeUtilsRef) {
+		t.Errorf("FlakeUtilsRef not substituted, got: %s", out)
+	}
+	if !strings.Contains(out, AwsNitroUtilRef) {
+		t.Errorf("AwsNitroUtilRef not substituted, got: %s", out)
+	}
+	for _, p := range []string{"{{NixpkgsRef}}", "{{FlakeUtilsRef}}", "{{AwsNitroUtilRef}}"} {
+		if strings.Contains(out, p) {
+			t.Errorf("placeholder %s leaked, got: %s", p, out)
+		}
+	}
+}
+
+func TestRunPinCheck_RejectsInvalidPin(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{"no pin", &Config{}},
+		{"short rev", &Config{Nix: NixConfig{NixpkgsRev: "abc", NixpkgsHash: testHash}}},
+		{"hash missing prefix", &Config{Nix: NixConfig{NixpkgsRev: testRev, NixpkgsHash: "abc"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := runPinCheck(tt.cfg); err == nil {
+				t.Errorf("expected error for %s", tt.name)
+			}
+		})
+	}
+}
+
+func TestRunPinCheck_AcceptsValidPin(t *testing.T) {
+	cfg := &Config{Nix: NixConfig{NixpkgsRev: testRev, NixpkgsHash: testHash}}
+	if err := runPinCheck(cfg); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestDecodeNixBase32_AllZeros(t *testing.T) {
+	// Index 0 in the Nix base32 alphabet is '0', so a string of 52 zeros
+	// decodes to 32 zero bytes.
+	out, err := decodeNixBase32(strings.Repeat("0", 52))
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(out) != 32 {
+		t.Errorf("expected 32 bytes, got %d", len(out))
+	}
+	for i, b := range out {
+		if b != 0 {
+			t.Errorf("byte %d = %d, want 0", i, b)
+		}
+	}
+}
+
+func TestDecodeNixBase32_RejectsWrongLength(t *testing.T) {
+	if _, err := decodeNixBase32("abc"); err == nil {
+		t.Error("expected error for short input")
+	}
+}
+
+func TestDecodeNixBase32_RejectsInvalidChar(t *testing.T) {
+	// 'e', 'o', 't', 'u' are NOT in the Nix base32 alphabet.
+	in := strings.Repeat("0", 51) + "e"
+	if _, err := decodeNixBase32(in); err == nil {
+		t.Error("expected error for invalid char")
+	}
+}
+
+func TestNixHashToSRI_PassThroughSRI(t *testing.T) {
+	out, err := nixHashToSRI(testHash)
+	if err != nil {
+		t.Fatalf("nixHashToSRI: %v", err)
+	}
+	if out != testHash {
+		t.Errorf("expected pass-through, got %q", out)
+	}
+}

--- a/cli/nixpkgs_cmd_test.go
+++ b/cli/nixpkgs_cmd_test.go
@@ -9,7 +9,8 @@ import (
 
 const (
 	testRev  = "0d843eedba88d22a7eaa2a7e54a2c1d8c0c0d4f8"
-	testHash = "sha256-aBcDeFgHiJkLmNoPqRsTuVwXyZ0123456789abcdef="
+	// SRI sha256 of the empty string (43 base64 chars + "=") — real, valid.
+	testHash = "sha256-47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU="
 )
 
 func TestUpdateNixpkgsInYaml_AppendsBlockWhenMissing(t *testing.T) {
@@ -182,6 +183,30 @@ func TestApplyNixpkgsRef_SubstitutesProvidedRef(t *testing.T) {
 	}
 	if strings.Contains(out, "{{NixpkgsRef}}") {
 		t.Errorf("placeholder should be gone, got: %s", out)
+	}
+}
+
+func TestGetInitFilesWithNixpkgs_PreservesOperatorPin(t *testing.T) {
+	pinSHA := "0d843eedba88d22a7eaa2a7e54a2c1d8c0c0d4f8"
+	for _, lang := range []string{"go", "nodejs", "dotnet", "rust"} {
+		t.Run(lang, func(t *testing.T) {
+			files := getInitFilesWithNixpkgs(lang, pinSHA)
+			var flake string
+			for _, f := range files {
+				if f.RelPath == "enclave/flake.nix" {
+					flake = f.Content
+				}
+			}
+			if flake == "" {
+				t.Fatal("no flake.nix in init files")
+			}
+			if !strings.Contains(flake, pinSHA) {
+				t.Errorf("operator's pin %q missing from scaffolded flake.nix — setup --force-flake regression risk", pinSHA)
+			}
+			if strings.Contains(flake, DefaultNixpkgsRef) {
+				t.Errorf("default ref %q leaked into scaffolded flake when operator pin was provided", DefaultNixpkgsRef)
+			}
+		})
 	}
 }
 

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -144,7 +144,11 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	}
 
 	// 5. Compute vendor/deps hash via trial nix build.
-	if language == "dotnet" {
+	// In vendor mode, skip entirely — the committed vendor/ directory is
+	// the source of truth; no hash to compute.
+	if cfg.App.Vendor {
+		fmt.Println("[setup] vendor: true — skipping vendor hash discovery (using committed vendor/)")
+	} else if language == "dotnet" {
 		fmt.Println("[setup] Generating NuGet deps.json...")
 		vendorErr = generateDotnetDeps(root)
 		if vendorErr == nil {
@@ -162,10 +166,12 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		} else {
 			fmt.Println("[setup] Will update other fields; you'll need to fill nix_vendor_hash manually.")
 		}
-	} else if language == "dotnet" {
-		fmt.Println("[setup] deps.json generated successfully")
-	} else {
-		fmt.Printf("[setup] nix_vendor_hash: %s\n", vendorHash)
+	} else if !cfg.App.Vendor {
+		if language == "dotnet" {
+			fmt.Println("[setup] deps.json generated successfully")
+		} else {
+			fmt.Printf("[setup] nix_vendor_hash: %s\n", vendorHash)
+		}
 	}
 
 	// 5. Update enclave.yaml preserving comments.
@@ -193,7 +199,7 @@ func runSetup(cmd *cobra.Command, args []string) error {
 
 	fmt.Println()
 	fmt.Printf("[setup] Updated %s\n", configFile)
-	if vendorHash == "" {
+	if vendorHash == "" && !cfg.App.Vendor {
 		fmt.Println()
 		if language == "dotnet" {
 			fmt.Println("Warning: deps.json was not generated.")

--- a/cli/setup.go
+++ b/cli/setup.go
@@ -74,7 +74,7 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	// would be silently clobbered on every `enclave setup` run. Pass
 	// --force-flake to regenerate, e.g. after changing language in enclave.yaml.
 	forceFlake, _ := cmd.Flags().GetBool("force-flake")
-	for _, f := range getInitFiles(language) {
+	for _, f := range getInitFilesWithNixpkgs(language, cfg.Nix.NixpkgsRev) {
 		if f.RelPath == "enclave/flake.nix" {
 			destPath := filepath.Join(root, f.RelPath)
 			if _, statErr := os.Stat(destPath); statErr == nil && !forceFlake {

--- a/cli/tofu_files.go
+++ b/cli/tofu_files.go
@@ -932,7 +932,7 @@ resource "aws_subnet" "public" {
   tags = { Name = "${local.prefix}-public" }
 }
 
-# Private subnet (for VPC endpoints and NAT egress).
+# Private subnet (for VPC endpoint ENIs).
 resource "aws_subnet" "private" {
   count = var.local ? 0 : 1
 
@@ -962,25 +962,6 @@ resource "aws_internet_gateway" "main" {
   tags = { Name = "${local.prefix}-igw" }
 }
 
-# NAT gateway for private subnet egress.
-resource "aws_eip" "nat" {
-  count  = var.local ? 0 : 1
-  domain = "vpc"
-
-  tags = { Name = "${local.prefix}-nat-eip" }
-}
-
-resource "aws_nat_gateway" "main" {
-  count = var.local ? 0 : 1
-
-  allocation_id = aws_eip.nat[0].id
-  subnet_id     = aws_subnet.public[0].id
-
-  tags = { Name = "${local.prefix}-nat" }
-
-  depends_on = [aws_internet_gateway.main]
-}
-
 # Route tables.
 resource "aws_route_table" "public" {
   count  = var.local ? 0 : 1
@@ -1000,14 +981,12 @@ resource "aws_route_table_association" "public" {
   route_table_id = aws_route_table.public[0].id
 }
 
+# No default route — private subnets only host VPC endpoint ENIs.
+# Interface endpoints (KMS, SSM) are reached directly via their in-subnet ENI;
+# S3 via the gateway endpoint route added below. No egress path needed.
 resource "aws_route_table" "private" {
   count  = var.local ? 0 : 1
   vpc_id = aws_vpc.main[0].id
-
-  route {
-    cidr_block     = "0.0.0.0/0"
-    nat_gateway_id = aws_nat_gateway.main[0].id
-  }
 
   tags = { Name = "${local.prefix}-private-rt" }
 }

--- a/cli/update.go
+++ b/cli/update.go
@@ -103,7 +103,9 @@ func runUpdate(cmd *cobra.Command, args []string) error {
 	}
 
 	if !skipDeps {
-		if language == "dotnet" {
+		if cfg.App.Vendor {
+			fmt.Println("[update] vendor: true — skipping vendor hash (using committed vendor/)")
+		} else if language == "dotnet" {
 			fmt.Println("[update] Generating NuGet deps.json...")
 			if dErr := generateDotnetDeps(root); dErr != nil {
 				fmt.Printf("[update] Warning: could not generate deps.json: %v\n", dErr)

--- a/cli/vendor_cmd.go
+++ b/cli/vendor_cmd.go
@@ -1,0 +1,115 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+)
+
+func vendorCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "vendor",
+		Short: "Vendor the upstream app's dependencies into ./vendor for offline builds",
+		Long: `Resolves the language from enclave.yaml, then shells out to
+'cargo vendor' (Rust) or 'go mod vendor' (Go) in the upstream app's
+checked-out source tree. After running, commit vendor/ and push, then
+run 'enclave setup' to refresh nix_rev / nix_hash, then flip
+'app.vendor: true' in enclave.yaml.
+
+The framework does NOT vendor for you automatically — the upstream
+repo lives outside the framework's working tree. Use --path to point at
+your local checkout of the upstream app.`,
+		RunE: runVendor,
+	}
+	cmd.Flags().String("path", ".", "path to the upstream app's checked-out source")
+	return cmd
+}
+
+func runVendor(cmd *cobra.Command, args []string) error {
+	appPath, _ := cmd.Flags().GetString("path")
+
+	cfg, err := loadConfig()
+	if err != nil {
+		return err
+	}
+
+	name, vendorArgs, err := vendorCommandFor(cfg.App.Language)
+	if err != nil {
+		return err
+	}
+
+	cwd, err := resolveVendorCwd(appPath, cfg.App.NixSubdir)
+	if err != nil {
+		return err
+	}
+
+	if _, err := exec.LookPath(name); err != nil {
+		return fmt.Errorf("%q not found on PATH — install the %s toolchain before running `enclave vendor`", name, cfg.App.Language)
+	}
+
+	fmt.Printf("[vendor] Running `%s %s` in %s...\n", name, joinArgs(vendorArgs), cwd)
+	c := exec.Command(name, vendorArgs...)
+	c.Dir = cwd
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("%s %s: %w", name, joinArgs(vendorArgs), err)
+	}
+
+	fmt.Println()
+	fmt.Println("[vendor] Done. Next steps (order matters):")
+	fmt.Println("  1. git add vendor/ && git commit -m 'vendor deps' && git push")
+	fmt.Println("  2. Edit enclave/enclave.yaml: set `app.vendor: true` and clear `app.nix_vendor_hash`")
+	fmt.Println("  3. From the framework project root, run `enclave setup` to refresh nix_rev/nix_hash")
+	fmt.Println("     (setup sees vendor: true and skips the hash-discovery step — required if you're")
+	fmt.Println("      recovering from a yanked upstream dep, since hash discovery would re-fetch it)")
+	fmt.Println("  4. `enclave build` — Nix uses the committed vendor/; no upstream fetch for app deps")
+	return nil
+}
+
+// vendorCommandFor returns the toolchain command + args that vendor deps for
+// the given language. Returns an error for languages without a clean
+// vendor-mode equivalent. Pure function so tests can exercise routing
+// without spawning processes.
+func vendorCommandFor(language string) (cmd string, args []string, err error) {
+	switch language {
+	case "rust":
+		return "cargo", []string{"vendor"}, nil
+	case "go":
+		return "go", []string{"mod", "vendor"}, nil
+	case "nodejs":
+		return "", nil, fmt.Errorf("vendor mode is not supported for language=nodejs (buildNpmPackage has no clean vendor-mode equivalent — npmDepsHash is mandatory)")
+	case "dotnet":
+		return "", nil, fmt.Errorf("vendor mode is not needed for language=dotnet — nugetDeps already manifests every package with content-addressed fetches")
+	default:
+		return "", nil, fmt.Errorf("unknown language %q (expected go|rust|nodejs|dotnet)", language)
+	}
+}
+
+// resolveVendorCwd returns the directory where the vendor command should run.
+// For Rust with nix_subdir set, cargoVendorDir is relative to cargoRoot, so
+// the vendor command must run in that subdir.
+func resolveVendorCwd(appPath, nixSubdir string) (string, error) {
+	abs, err := filepath.Abs(appPath)
+	if err != nil {
+		return "", fmt.Errorf("resolve --path: %w", err)
+	}
+	if nixSubdir != "" {
+		return filepath.Join(abs, nixSubdir), nil
+	}
+	return abs, nil
+}
+
+func joinArgs(args []string) string {
+	out := ""
+	for i, a := range args {
+		if i > 0 {
+			out += " "
+		}
+		out += a
+	}
+	return out
+}

--- a/cli/vendor_cmd_test.go
+++ b/cli/vendor_cmd_test.go
@@ -1,0 +1,101 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestVendorCommandFor_Rust(t *testing.T) {
+	name, args, err := vendorCommandFor("rust")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "cargo" || !equalStrings(args, []string{"vendor"}) {
+		t.Errorf("rust → got %q %v, want cargo [vendor]", name, args)
+	}
+}
+
+func TestVendorCommandFor_Go(t *testing.T) {
+	name, args, err := vendorCommandFor("go")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if name != "go" || !equalStrings(args, []string{"mod", "vendor"}) {
+		t.Errorf("go → got %q %v, want go [mod vendor]", name, args)
+	}
+}
+
+func TestVendorCommandFor_UnsupportedLanguages(t *testing.T) {
+	for _, lang := range []string{"nodejs", "dotnet", "python", "", "RUST"} {
+		t.Run(lang, func(t *testing.T) {
+			_, _, err := vendorCommandFor(lang)
+			if err == nil {
+				t.Errorf("expected error for language %q", lang)
+			}
+		})
+	}
+}
+
+func TestResolveVendorCwd_NoSubdir(t *testing.T) {
+	dir := t.TempDir()
+	got, err := resolveVendorCwd(dir, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(dir)
+	if got != abs {
+		t.Errorf("got %q, want %q", got, abs)
+	}
+}
+
+func TestResolveVendorCwd_WithSubdir(t *testing.T) {
+	dir := t.TempDir()
+	got, err := resolveVendorCwd(dir, "cosigner-runtime")
+	if err != nil {
+		t.Fatal(err)
+	}
+	abs, _ := filepath.Abs(dir)
+	want := filepath.Join(abs, "cosigner-runtime")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestFrameworkFlakeRust_VendorConditional(t *testing.T) {
+	rust := applyNixpkgsRef(frameworkFlakeNixRust, "")
+	wants := []string{
+		`if (appCfg.vendor or false)`,
+		`then { cargoVendorDir = "vendor"; }`,
+		`else { cargoHash =`,
+		`runCommand "vendor-hash-check-noop"`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(rust, w) {
+			t.Errorf("Rust flake template missing fragment %q", w)
+		}
+	}
+}
+
+func TestFrameworkFlakeGo_VendorConditional(t *testing.T) {
+	gop := applyNixpkgsRef(frameworkFlakeNix, "")
+	wants := []string{
+		`vendorHash = if (appCfg.vendor or false) then null`,
+		`proxyVendor = !(appCfg.vendor or false);`,
+		`runCommand "vendor-hash-check-noop"`,
+	}
+	for _, w := range wants {
+		if !strings.Contains(gop, w) {
+			t.Errorf("Go flake template missing fragment %q", w)
+		}
+	}
+}
+
+func TestFrameworkFlakeNodejs_NoVendorConditional(t *testing.T) {
+	node := applyNixpkgsRef(frameworkFlakeNixNodejs, "")
+	// Node should NOT have the vendor conditional — vendor mode is rejected
+	// for nodejs at config-load.
+	if strings.Contains(node, `if (appCfg.vendor or false)`) {
+		t.Errorf("Node flake template should not have vendor conditional (vendor mode is rejected for nodejs)")
+	}
+}

--- a/test/app/cmd/main.go
+++ b/test/app/cmd/main.go
@@ -112,13 +112,16 @@ func main() {
 	mux.HandleFunc("GET /", handleRoot)
 	mux.HandleFunc("GET /test/secrets", handleTestSecrets)
 	mux.HandleFunc("GET /test/storage", handleTestStorage)
-	mux.HandleFunc("GET /test/storage-persistence", handleTestStoragePersistence)
+	mux.HandleFunc("POST /test/storage-persistence", handleTestStoragePersistenceWrite)
+	mux.HandleFunc("GET /test/storage-persistence", handleTestStoragePersistenceVerify)
 	mux.HandleFunc("GET /test/attestation", handleTestAttestation)
 	mux.HandleFunc("GET /test/attestation-document", handleTestAttestationDocument)
 	mux.HandleFunc("GET /test/dynamic-secrets", handleTestDynamicSecrets)
-	mux.HandleFunc("GET /test/dynamic-secret-persistence", handleTestDynamicSecretPersistence)
+	mux.HandleFunc("POST /test/dynamic-secret-persistence", handleTestDynamicSecretPersistenceWrite)
+	mux.HandleFunc("GET /test/dynamic-secret-persistence", handleTestDynamicSecretPersistenceVerify)
 	mux.HandleFunc("GET /test/pcr-secrets", handleTestPCRSecrets)
-	mux.HandleFunc("GET /test/attestation-persistence", handleTestAttestationPersistence)
+	mux.HandleFunc("POST /test/attestation-persistence", handleTestAttestationPersistenceWrite)
+	mux.HandleFunc("GET /test/attestation-persistence", handleTestAttestationPersistenceVerify)
 	mux.HandleFunc("GET /test/attestation-binding", handleTestAttestationBinding)
 	mux.HandleFunc("GET /test/logs", handleTestLogs)
 	mux.HandleFunc("GET /test/env-override", handleTestEnvOverride)
@@ -366,70 +369,76 @@ func handleTestStorage(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(results)
 }
 
-// handleTestStoragePersistence writes a well-known key to storage (or reads it back).
-// First call (key doesn't exist): writes "persistent-test-value" → returns {"phase":"write"}.
-// Second call (key exists): reads it back and verifies → returns {"phase":"verify","roundtrip":true}.
-// This lets the test suite verify storage survives across migration/restart.
-func handleTestStoragePersistence(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+const (
+	storagePersistKey   = "test/persistence-check"
+	storagePersistValue = "persistent-test-value"
+)
 
+// handleTestStoragePersistenceWrite (POST) unconditionally writes the well-known
+// key+value to storage. Deletes any stale value first so re-runs don't carry
+// over data from a previous test run.
+func handleTestStoragePersistenceWrite(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	token := os.Getenv("ENCLAVE_RUNTIME_TOKEN")
 	if token == "" {
 		http.Error(w, `{"error":"ENCLAVE_RUNTIME_TOKEN not set"}`, http.StatusInternalServerError)
 		return
 	}
-
-	const persistKey = "test/persistence-check"
-	const persistValue = "persistent-test-value"
-	results := map[string]any{"key": persistKey}
-
-	// Try to GET first — if it exists, we're in verify phase.
-	getReq, _ := http.NewRequest("GET", supervisorURL+"/v1/storage/"+persistKey, nil)
-	getReq.Header.Set("Authorization", "Bearer "+token)
-	getResp, err := http.DefaultClient.Do(getReq)
-	if err != nil {
-		results["error"] = fmt.Sprintf("get failed: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
-		return
+	// Delete first (idempotent — 404 is fine).
+	delReq, _ := http.NewRequest("DELETE", supervisorURL+"/v1/storage/"+storagePersistKey, nil)
+	delReq.Header.Set("Authorization", "Bearer "+token)
+	resp, _ := http.DefaultClient.Do(delReq)
+	if resp != nil {
+		resp.Body.Close()
 	}
-	body, _ := io.ReadAll(getResp.Body)
-	getResp.Body.Close()
-
-	if getResp.StatusCode == http.StatusOK && len(body) > 0 {
-		// Verify phase: key existed, check value matches.
-		results["phase"] = "verify"
-		if string(body) == persistValue {
-			results["roundtrip"] = true
-			results["status"] = "ok"
-		} else {
-			results["error"] = fmt.Sprintf("value mismatch: got %q, want %q", string(body), persistValue)
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-		json.NewEncoder(w).Encode(results)
-		return
-	}
-
-	// Write phase: key doesn't exist yet, create it.
-	putReq, _ := http.NewRequest("PUT", supervisorURL+"/v1/storage/"+persistKey, bytes.NewReader([]byte(persistValue)))
+	// Write the known value.
+	putReq, _ := http.NewRequest("PUT", supervisorURL+"/v1/storage/"+storagePersistKey, bytes.NewReader([]byte(storagePersistValue)))
 	putReq.Header.Set("Authorization", "Bearer "+token)
 	putResp, err := http.DefaultClient.Do(putReq)
 	if err != nil {
-		results["error"] = fmt.Sprintf("put failed: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
+		http.Error(w, fmt.Sprintf(`{"error":"put failed: %v"}`, err), http.StatusInternalServerError)
 		return
 	}
 	putResp.Body.Close()
 	if putResp.StatusCode != http.StatusCreated {
-		results["error"] = fmt.Sprintf("put returned %d", putResp.StatusCode)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
+		http.Error(w, fmt.Sprintf(`{"error":"put returned %d"}`, putResp.StatusCode), http.StatusInternalServerError)
 		return
 	}
-	results["phase"] = "write"
-	results["status"] = "ok"
-	json.NewEncoder(w).Encode(results)
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "key": storagePersistKey})
+}
+
+// handleTestStoragePersistenceVerify (GET) reads the well-known key and compares
+// it to the expected value. Returns 404 if the key is missing (data lost during
+// migration), 500 if the value is wrong, 200 if it matches exactly.
+func handleTestStoragePersistenceVerify(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	token := os.Getenv("ENCLAVE_RUNTIME_TOKEN")
+	if token == "" {
+		http.Error(w, `{"error":"ENCLAVE_RUNTIME_TOKEN not set"}`, http.StatusInternalServerError)
+		return
+	}
+	getReq, _ := http.NewRequest("GET", supervisorURL+"/v1/storage/"+storagePersistKey, nil)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"get failed: %v"}`, err), http.StatusInternalServerError)
+		return
+	}
+	body, _ := io.ReadAll(getResp.Body)
+	getResp.Body.Close()
+	if getResp.StatusCode == http.StatusNotFound {
+		http.Error(w, `{"error":"key not found — data lost during migration"}`, http.StatusNotFound)
+		return
+	}
+	if getResp.StatusCode != http.StatusOK {
+		http.Error(w, fmt.Sprintf(`{"error":"storage get returned %d"}`, getResp.StatusCode), http.StatusInternalServerError)
+		return
+	}
+	if string(body) != storagePersistValue {
+		http.Error(w, fmt.Sprintf(`{"error":"value mismatch: got %q, want %q"}`, string(body), storagePersistValue), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "key": storagePersistKey})
 }
 
 // handleTestDynamicSecrets exercises the dynamic secrets API:
@@ -541,79 +550,81 @@ func handleTestDynamicSecrets(w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(results)
 }
 
-// handleTestDynamicSecretPersistence creates or verifies a well-known dynamic secret.
-// First call (secret doesn't exist): creates "migration-persist-secret" → returns {"phase":"write"}.
-// Second call (secret exists): reads it back and verifies → returns {"phase":"verify","roundtrip":true}.
-// This lets the test suite verify dynamic secrets survive across migration/restart.
-func handleTestDynamicSecretPersistence(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+const (
+	dynPersistName  = "migration-persist-secret"
+	dynPersistValue = "pre-migration-value"
+	dynPersistEnv   = "TEST_PERSIST_SECRET"
+)
 
+// handleTestDynamicSecretPersistenceWrite (POST) unconditionally writes the
+// well-known dynamic secret. Deletes any stale value first.
+func handleTestDynamicSecretPersistenceWrite(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	token := os.Getenv("ENCLAVE_RUNTIME_TOKEN")
 	if token == "" {
 		http.Error(w, `{"error":"ENCLAVE_RUNTIME_TOKEN not set"}`, http.StatusInternalServerError)
 		return
 	}
-
-	const persistName = "migration-persist-secret"
-	const persistValue = "pre-migration-value"
-	const persistEnvVar = "TEST_PERSIST_SECRET"
-	results := map[string]any{"name": persistName}
-
-	// Try GET first — if it exists, we're in verify phase.
-	getReq, _ := http.NewRequest("GET", supervisorURL+"/v1/secrets/"+persistName, nil)
-	getReq.Header.Set("Authorization", "Bearer "+token)
-	getResp, err := http.DefaultClient.Do(getReq)
-	if err != nil {
-		results["error"] = fmt.Sprintf("get failed: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
-		return
+	// Delete first (idempotent).
+	delReq, _ := http.NewRequest("DELETE", supervisorURL+"/v1/secrets/"+dynPersistName, nil)
+	delReq.Header.Set("Authorization", "Bearer "+token)
+	resp, _ := http.DefaultClient.Do(delReq)
+	if resp != nil {
+		resp.Body.Close()
 	}
-	getBody, _ := io.ReadAll(getResp.Body)
-	getResp.Body.Close()
-
-	if getResp.StatusCode == http.StatusOK && len(getBody) > 0 {
-		var secretResp struct {
-			Value string `json:"value"`
-		}
-		json.Unmarshal(getBody, &secretResp)
-		results["phase"] = "verify"
-		if secretResp.Value == persistValue {
-			results["roundtrip"] = true
-			results["status"] = "ok"
-		} else {
-			results["error"] = fmt.Sprintf("value mismatch: got %q, want %q", secretResp.Value, persistValue)
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-		json.NewEncoder(w).Encode(results)
-		return
-	}
-
-	// Write phase: secret doesn't exist yet, create it.
-	putBody, _ := json.Marshal(map[string]string{
-		"value":   persistValue,
-		"env_var": persistEnvVar,
-	})
-	putReq, _ := http.NewRequest("PUT", supervisorURL+"/v1/secrets/"+persistName, bytes.NewReader(putBody))
+	putBody, _ := json.Marshal(map[string]string{"value": dynPersistValue, "env_var": dynPersistEnv})
+	putReq, _ := http.NewRequest("PUT", supervisorURL+"/v1/secrets/"+dynPersistName, bytes.NewReader(putBody))
 	putReq.Header.Set("Authorization", "Bearer "+token)
 	putReq.Header.Set("Content-Type", "application/json")
 	putResp, err := http.DefaultClient.Do(putReq)
 	if err != nil {
-		results["error"] = fmt.Sprintf("put failed: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
+		http.Error(w, fmt.Sprintf(`{"error":"put failed: %v"}`, err), http.StatusInternalServerError)
 		return
 	}
 	putResp.Body.Close()
 	if putResp.StatusCode != http.StatusCreated {
-		results["error"] = fmt.Sprintf("put returned %d", putResp.StatusCode)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
+		http.Error(w, fmt.Sprintf(`{"error":"put returned %d"}`, putResp.StatusCode), http.StatusInternalServerError)
 		return
 	}
-	results["phase"] = "write"
-	results["status"] = "ok"
-	json.NewEncoder(w).Encode(results)
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "name": dynPersistName})
+}
+
+// handleTestDynamicSecretPersistenceVerify (GET) reads the well-known dynamic
+// secret and compares it to the expected value. Returns 404 if missing, 500 if
+// the value is wrong, 200 if it matches.
+func handleTestDynamicSecretPersistenceVerify(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	token := os.Getenv("ENCLAVE_RUNTIME_TOKEN")
+	if token == "" {
+		http.Error(w, `{"error":"ENCLAVE_RUNTIME_TOKEN not set"}`, http.StatusInternalServerError)
+		return
+	}
+	getReq, _ := http.NewRequest("GET", supervisorURL+"/v1/secrets/"+dynPersistName, nil)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"get failed: %v"}`, err), http.StatusInternalServerError)
+		return
+	}
+	body, _ := io.ReadAll(getResp.Body)
+	getResp.Body.Close()
+	if getResp.StatusCode == http.StatusNotFound {
+		http.Error(w, `{"error":"secret not found — data lost during migration"}`, http.StatusNotFound)
+		return
+	}
+	if getResp.StatusCode != http.StatusOK {
+		http.Error(w, fmt.Sprintf(`{"error":"get returned %d"}`, getResp.StatusCode), http.StatusInternalServerError)
+		return
+	}
+	var secretResp struct {
+		Value string `json:"value"`
+	}
+	json.Unmarshal(body, &secretResp)
+	if secretResp.Value != dynPersistValue {
+		http.Error(w, fmt.Sprintf(`{"error":"value mismatch: got %q, want %q"}`, secretResp.Value, dynPersistValue), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "name": dynPersistName})
 }
 
 // handleTestPCRSecrets verifies secret-to-PCR derivation math and that the
@@ -971,58 +982,45 @@ func fetchAttestationDoc() (*attestationPayload, error) {
 	return &doc, nil
 }
 
-// handleTestAttestationPersistence verifies that the attestation pubkey and
-// PCR16 extension hash survive migration. Uses the write/verify pattern:
-//
-// First call (pre-migration): derives pubkey + PCR16 hash from SIGNING_KEY,
-// fetches attestation_pubkey from supervisor, stores all three values to
-// encrypted storage → returns {"phase":"write"}.
-//
-// Second call (post-migration): reads stored values, re-derives current values,
-// compares → returns {"phase":"verify","pubkey_match":true,"pcr16_match":true}.
-func handleTestAttestationPersistence(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Content-Type", "application/json")
+const attestPersistStorageKey = "test/attestation-persistence"
 
+// deriveAttestationValues computes the current pubkey and PCR16 from SIGNING_KEY.
+func deriveAttestationValues() (pubkey, pcr16 string, err error) {
+	signingKeyHex := os.Getenv("SIGNING_KEY")
+	if signingKeyHex == "" {
+		return "", "", fmt.Errorf("SIGNING_KEY not set")
+	}
+	secretBytes, decErr := hex.DecodeString(signingKeyHex)
+	if decErr != nil || len(secretBytes) != 32 {
+		return "", "", fmt.Errorf("SIGNING_KEY invalid: %v", decErr)
+	}
+	privKey, _ := btcec.PrivKeyFromBytes(secretBytes)
+	compressedPubkey := privKey.PubKey().SerializeCompressed()
+	extensionData := sha256.Sum256(compressedPubkey)
+	var zeros48 [48]byte
+	extendInput := append(zeros48[:], extensionData[:]...)
+	actualPCR16 := sha512.Sum384(extendInput)
+	return hex.EncodeToString(compressedPubkey), hex.EncodeToString(actualPCR16[:]), nil
+}
+
+// handleTestAttestationPersistenceWrite (POST) derives pubkey + PCR16 from the
+// current SIGNING_KEY, fetches attestation_pubkey from the supervisor, and stores
+// all three to encrypted storage. Deletes any stale value first.
+func handleTestAttestationPersistenceWrite(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
 	token := os.Getenv("ENCLAVE_RUNTIME_TOKEN")
 	if token == "" {
 		http.Error(w, `{"error":"ENCLAVE_RUNTIME_TOKEN not set"}`, http.StatusInternalServerError)
 		return
 	}
-
-	results := map[string]any{}
-
-	// Derive current attestation values from SIGNING_KEY.
-	signingKeyHex := os.Getenv("SIGNING_KEY")
-	if signingKeyHex == "" {
-		results["error"] = "SIGNING_KEY not set"
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
+	pubkey, pcr16, err := deriveAttestationValues()
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
 		return
 	}
-	secretBytes, err := hex.DecodeString(signingKeyHex)
-	if err != nil || len(secretBytes) != 32 {
-		results["error"] = fmt.Sprintf("SIGNING_KEY invalid: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
-		return
-	}
-	privKey, _ := btcec.PrivKeyFromBytes(secretBytes)
-	compressedPubkey := privKey.PubKey().SerializeCompressed()
-	extensionData := sha256.Sum256(compressedPubkey)
-	// Compute actual PCR16: SHA384(zeros_48 || SHA256(compressed_pubkey)).
-	// Nitro PCRs 16-31 start as 48 zero bytes, ExtendPCR computes SHA384(old || data).
-	var zeros48 [48]byte
-	extendInput := append(zeros48[:], extensionData[:]...)
-	actualPCR16 := sha512.Sum384(extendInput)
-	currentPCR16 := hex.EncodeToString(actualPCR16[:])
-	currentPubkey := hex.EncodeToString(compressedPubkey)
-
-	// Fetch attestation_pubkey from supervisor (the ephemeral key used for signing).
 	infoResp, err := http.Get(supervisorURL + "/v1/enclave-info")
 	if err != nil {
-		results["error"] = fmt.Sprintf("fetch enclave-info: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
+		http.Error(w, fmt.Sprintf(`{"error":"fetch enclave-info: %v"}`, err), http.StatusInternalServerError)
 		return
 	}
 	infoBody, _ := io.ReadAll(infoResp.Body)
@@ -1031,77 +1029,88 @@ func handleTestAttestationPersistence(w http.ResponseWriter, r *http.Request) {
 		AttestationPubkey string `json:"attestation_pubkey"`
 	}
 	json.Unmarshal(infoBody, &info)
-	currentAttestPubkey := info.AttestationPubkey
 
-	const storageKey = "test/attestation-persistence"
-
-	// Try GET — if stored data exists, we're in verify phase.
-	getReq, _ := http.NewRequest("GET", supervisorURL+"/v1/storage/"+storageKey, nil)
-	getReq.Header.Set("Authorization", "Bearer "+token)
-	getResp, err := http.DefaultClient.Do(getReq)
-	if err != nil {
-		results["error"] = fmt.Sprintf("storage get: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
-		return
-	}
-	storedBody, _ := io.ReadAll(getResp.Body)
-	getResp.Body.Close()
-
-	if getResp.StatusCode == http.StatusOK && len(storedBody) > 0 {
-		// Verify phase: compare stored pre-migration values with current.
-		var stored struct {
-			Pubkey string `json:"pubkey"`
-			PCR16  string `json:"pcr16"`
-		}
-		json.Unmarshal(storedBody, &stored)
-
-		results["phase"] = "verify"
-		results["pre_migration_pubkey"] = stored.Pubkey
-		results["post_migration_pubkey"] = currentPubkey
-		results["pubkey_match"] = stored.Pubkey == currentPubkey
-		results["pre_migration_pcr16"] = stored.PCR16
-		results["post_migration_pcr16"] = currentPCR16
-		results["pcr16_match"] = stored.PCR16 == currentPCR16
-
-		if stored.Pubkey == currentPubkey && stored.PCR16 == currentPCR16 {
-			results["status"] = "ok"
-		} else {
-			results["error"] = "attestation values changed after migration"
-			w.WriteHeader(http.StatusInternalServerError)
-		}
-		json.NewEncoder(w).Encode(results)
-		return
+	// Delete stale value first.
+	delReq, _ := http.NewRequest("DELETE", supervisorURL+"/v1/storage/"+attestPersistStorageKey, nil)
+	delReq.Header.Set("Authorization", "Bearer "+token)
+	resp, _ := http.DefaultClient.Do(delReq)
+	if resp != nil {
+		resp.Body.Close()
 	}
 
-	// Write phase: store current values for post-migration comparison.
 	storeData, _ := json.Marshal(map[string]string{
-		"pubkey":        currentPubkey,
-		"pcr16":         currentPCR16,
-		"attest_pubkey": currentAttestPubkey,
+		"pubkey":        pubkey,
+		"pcr16":         pcr16,
+		"attest_pubkey": info.AttestationPubkey,
 	})
-	putReq, _ := http.NewRequest("PUT", supervisorURL+"/v1/storage/"+storageKey, bytes.NewReader(storeData))
+	putReq, _ := http.NewRequest("PUT", supervisorURL+"/v1/storage/"+attestPersistStorageKey, bytes.NewReader(storeData))
 	putReq.Header.Set("Authorization", "Bearer "+token)
 	putResp, err := http.DefaultClient.Do(putReq)
 	if err != nil {
-		results["error"] = fmt.Sprintf("storage put: %v", err)
-		w.WriteHeader(http.StatusInternalServerError)
-		json.NewEncoder(w).Encode(results)
+		http.Error(w, fmt.Sprintf(`{"error":"storage put: %v"}`, err), http.StatusInternalServerError)
 		return
 	}
 	putResp.Body.Close()
 	if putResp.StatusCode != http.StatusCreated {
-		results["error"] = fmt.Sprintf("storage put returned %d", putResp.StatusCode)
+		http.Error(w, fmt.Sprintf(`{"error":"storage put returned %d"}`, putResp.StatusCode), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(map[string]any{"ok": true, "pubkey": pubkey, "pcr16": pcr16})
+}
+
+// handleTestAttestationPersistenceVerify (GET) reads the pre-migration values from
+// storage and compares them to the current derived values. Returns 404 if the stored
+// data is missing, 500 if pubkey or PCR16 changed, 200 if both match.
+func handleTestAttestationPersistenceVerify(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	token := os.Getenv("ENCLAVE_RUNTIME_TOKEN")
+	if token == "" {
+		http.Error(w, `{"error":"ENCLAVE_RUNTIME_TOKEN not set"}`, http.StatusInternalServerError)
+		return
+	}
+	currentPubkey, currentPCR16, err := deriveAttestationValues()
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":%q}`, err.Error()), http.StatusInternalServerError)
+		return
+	}
+	getReq, _ := http.NewRequest("GET", supervisorURL+"/v1/storage/"+attestPersistStorageKey, nil)
+	getReq.Header.Set("Authorization", "Bearer "+token)
+	getResp, err := http.DefaultClient.Do(getReq)
+	if err != nil {
+		http.Error(w, fmt.Sprintf(`{"error":"storage get: %v"}`, err), http.StatusInternalServerError)
+		return
+	}
+	storedBody, _ := io.ReadAll(getResp.Body)
+	getResp.Body.Close()
+	if getResp.StatusCode == http.StatusNotFound {
+		http.Error(w, `{"error":"attestation data not found — storage lost during migration"}`, http.StatusNotFound)
+		return
+	}
+	if getResp.StatusCode != http.StatusOK {
+		http.Error(w, fmt.Sprintf(`{"error":"storage get returned %d"}`, getResp.StatusCode), http.StatusInternalServerError)
+		return
+	}
+	var stored struct {
+		Pubkey string `json:"pubkey"`
+		PCR16  string `json:"pcr16"`
+	}
+	json.Unmarshal(storedBody, &stored)
+
+	results := map[string]any{
+		"pre_migration_pubkey":  stored.Pubkey,
+		"post_migration_pubkey": currentPubkey,
+		"pubkey_match":          stored.Pubkey == currentPubkey,
+		"pre_migration_pcr16":   stored.PCR16,
+		"post_migration_pcr16":  currentPCR16,
+		"pcr16_match":           stored.PCR16 == currentPCR16,
+	}
+	if stored.Pubkey != currentPubkey || stored.PCR16 != currentPCR16 {
+		results["error"] = "attestation values changed after migration"
 		w.WriteHeader(http.StatusInternalServerError)
 		json.NewEncoder(w).Encode(results)
 		return
 	}
-
-	results["phase"] = "write"
-	results["pubkey"] = currentPubkey
-	results["pcr16"] = currentPCR16
-	results["attest_pubkey"] = currentAttestPubkey
-	results["status"] = "ok"
+	results["ok"] = true
 	json.NewEncoder(w).Encode(results)
 }
 

--- a/test/integration-test.sh
+++ b/test/integration-test.sh
@@ -168,35 +168,34 @@ else
   fail "Attestation document" "${ATTEST_DOC_RESP:0:120}"
 fi
 
-# Test 13: Storage persistence (write a known key for post-migration verification).
-echo "[13/28] Storage persistence (write phase)"
-PERSIST_RESP=$($CURL "${BASE_URL}/test/storage-persistence" 2>/dev/null || echo "")
-if [ -n "$PERSIST_RESP" ] && echo "$PERSIST_RESP" | jq -e '.phase' >/dev/null 2>&1; then
-  PHASE=$(echo "$PERSIST_RESP" | jq -r '.phase' 2>/dev/null || echo "")
-  pass "Storage persistence $PHASE phase"
+# Test 13: Storage persistence — write a known key for post-migration verification.
+# Uses POST to unconditionally write (deletes stale data first), so the
+# post-migration GET verify always has a fresh baseline.
+echo "[13/28] Storage persistence (write)"
+PERSIST_RESP=$($CURL -X POST "${BASE_URL}/test/storage-persistence" 2>/dev/null || echo "")
+if echo "$PERSIST_RESP" | jq -e '.ok == true' >/dev/null 2>&1; then
+  pass "Storage persistence write"
 else
-  fail "Storage persistence" "${PERSIST_RESP:0:120}"
+  fail "Storage persistence write" "${PERSIST_RESP:0:120}"
 fi
 
-# Test 14: Dynamic secret persistence (write a known secret for post-migration verification).
-echo "[14/28] Dynamic secret persistence (write phase)"
-DYN_PERSIST_RESP=$($CURL "${BASE_URL}/test/dynamic-secret-persistence" 2>/dev/null || echo "")
-if [ -n "$DYN_PERSIST_RESP" ] && echo "$DYN_PERSIST_RESP" | jq -e '.phase' >/dev/null 2>&1; then
-  DYN_PHASE=$(echo "$DYN_PERSIST_RESP" | jq -r '.phase' 2>/dev/null || echo "")
-  pass "Dynamic secret persistence $DYN_PHASE phase"
+# Test 14: Dynamic secret persistence — write a known secret for post-migration verification.
+echo "[14/28] Dynamic secret persistence (write)"
+DYN_PERSIST_RESP=$($CURL -X POST "${BASE_URL}/test/dynamic-secret-persistence" 2>/dev/null || echo "")
+if echo "$DYN_PERSIST_RESP" | jq -e '.ok == true' >/dev/null 2>&1; then
+  pass "Dynamic secret persistence write"
 else
-  fail "Dynamic secret persistence" "${DYN_PERSIST_RESP:0:120}"
+  fail "Dynamic secret persistence write" "${DYN_PERSIST_RESP:0:120}"
 fi
 
-# Test 15: Attestation persistence (write pubkey + PCR16 hash for post-migration verification).
-echo "[15/28] Attestation persistence (write phase)"
-ATTEST_PERSIST=$($CURL "${BASE_URL}/test/attestation-persistence" 2>/dev/null || echo "")
-if [ -n "$ATTEST_PERSIST" ] && echo "$ATTEST_PERSIST" | jq -e '.phase' >/dev/null 2>&1; then
-  ATTEST_PHASE=$(echo "$ATTEST_PERSIST" | jq -r '.phase' 2>/dev/null || echo "")
+# Test 15: Attestation persistence — write pubkey + PCR16 hash for post-migration verification.
+echo "[15/28] Attestation persistence (write)"
+ATTEST_PERSIST=$($CURL -X POST "${BASE_URL}/test/attestation-persistence" 2>/dev/null || echo "")
+if echo "$ATTEST_PERSIST" | jq -e '.ok == true' >/dev/null 2>&1; then
   ATTEST_PCR16=$(echo "$ATTEST_PERSIST" | jq -r '.pcr16 // empty' 2>/dev/null || echo "")
-  pass "Attestation persistence $ATTEST_PHASE phase (PCR16: ${ATTEST_PCR16:0:16}...)"
+  pass "Attestation persistence write (PCR16: ${ATTEST_PCR16:0:16}...)"
 else
-  fail "Attestation persistence" "${ATTEST_PERSIST:0:120}"
+  fail "Attestation persistence write" "${ATTEST_PERSIST:0:120}"
 fi
 
 # Test 16: Schnorr signature still valid (sanity check before migration).

--- a/test/run.sh
+++ b/test/run.sh
@@ -955,14 +955,14 @@ else
 fi
 
 # Verify persistent storage key survived migration+restart (written in integration test 13).
+# GET /test/storage-persistence reads the known key and compares byte-for-byte.
+# 200+ok=true → data intact. 404 → data lost. 500 → value corrupted. All non-200 are FAIL.
 PERSIST_RESP=$(curl -sk --max-time 10 "https://localhost:${HOST_TLS_PORT:-8443}/test/storage-persistence" 2>/dev/null || echo "")
-PERSIST_PHASE=$(echo "$PERSIST_RESP" | jq -r '.phase // empty' 2>/dev/null || echo "")
-if [ "$PERSIST_PHASE" = "verify" ] && echo "$PERSIST_RESP" | jq -e '.roundtrip == true' >/dev/null 2>&1; then
+if echo "$PERSIST_RESP" | jq -e '.ok == true' >/dev/null 2>&1; then
   echo "  PASS: Persistent storage survived migration+restart"
-elif [ "$PERSIST_PHASE" = "write" ]; then
-  echo "  INFO: Persistent key was re-written (expected after full restart)"
 else
-  echo "  WARN: Could not verify storage persistence: ${PERSIST_RESP:0:120}"
+  echo "  FAIL: Persistent storage lost or corrupted during migration: ${PERSIST_RESP:0:200}" >&2
+  exit 1
 fi
 
 # Verify dynamic secrets API works after restart.
@@ -974,35 +974,26 @@ else
   exit 1
 fi
 
-# Verify attestation pubkey + PCR16 hash survived migration (write/verify pattern).
-# Pre-migration values were stored to encrypted storage in integration test 14.
+# Verify attestation pubkey + PCR16 survived migration (written in integration test 15).
+# GET /test/attestation-persistence re-derives current values and compares to stored.
+# 200+ok=true → SIGNING_KEY intact and derivation matches. 404 → storage lost. 500 → mismatch.
 ATTEST_PERSIST_RESP=$(curl -sk --max-time 10 "https://localhost:${HOST_TLS_PORT:-8443}/test/attestation-persistence" 2>/dev/null || echo "")
-ATTEST_PERSIST_PHASE=$(echo "$ATTEST_PERSIST_RESP" | jq -r '.phase // empty' 2>/dev/null || echo "")
-if [ "$ATTEST_PERSIST_PHASE" = "verify" ]; then
-  PUBKEY_MATCH=$(echo "$ATTEST_PERSIST_RESP" | jq -r '.pubkey_match // false' 2>/dev/null || echo "false")
-  PCR16_MATCH=$(echo "$ATTEST_PERSIST_RESP" | jq -r '.pcr16_match // false' 2>/dev/null || echo "false")
-  if [ "$PUBKEY_MATCH" = "true" ] && [ "$PCR16_MATCH" = "true" ]; then
-    echo "  PASS: Attestation pubkey + PCR16 identical after migration (SIGNING_KEY survived)"
-  else
-    echo "  FAIL: Attestation values changed after migration!" >&2
-    echo "$ATTEST_PERSIST_RESP" | jq . >&2
-    exit 1
-  fi
-elif [ "$ATTEST_PERSIST_PHASE" = "write" ]; then
-  echo "  INFO: Attestation persistence re-written (expected after full restart)"
+if echo "$ATTEST_PERSIST_RESP" | jq -e '.ok == true' >/dev/null 2>&1; then
+  echo "  PASS: Attestation pubkey + PCR16 identical after migration (SIGNING_KEY survived)"
 else
-  echo "  WARN: Could not verify attestation persistence: ${ATTEST_PERSIST_RESP:0:120}"
+  echo "  FAIL: Attestation data lost or changed during migration!" >&2
+  echo "$ATTEST_PERSIST_RESP" | jq . >&2
+  exit 1
 fi
 
-# Verify dynamic secret created before migration survived restart.
+# Verify dynamic secret created before migration survived restart (written in integration test 14).
+# GET /test/dynamic-secret-persistence reads the known secret and compares value byte-for-byte.
 DYN_PERSIST_RESP=$(curl -sk --max-time 10 "https://localhost:${HOST_TLS_PORT:-8443}/test/dynamic-secret-persistence" 2>/dev/null || echo "")
-DYN_PERSIST_PHASE=$(echo "$DYN_PERSIST_RESP" | jq -r '.phase // empty' 2>/dev/null || echo "")
-if [ "$DYN_PERSIST_PHASE" = "verify" ] && echo "$DYN_PERSIST_RESP" | jq -e '.roundtrip == true' >/dev/null 2>&1; then
+if echo "$DYN_PERSIST_RESP" | jq -e '.ok == true' >/dev/null 2>&1; then
   echo "  PASS: Dynamic secret survived migration+restart"
-elif [ "$DYN_PERSIST_PHASE" = "write" ]; then
-  echo "  INFO: Dynamic secret was re-written (expected after full restart)"
 else
-  echo "  WARN: Could not verify dynamic secret persistence: ${DYN_PERSIST_RESP:0:120}"
+  echo "  FAIL: Dynamic secret lost or corrupted during migration: ${DYN_PERSIST_RESP:0:200}" >&2
+  exit 1
 fi
 
 # Step 8.5: Verify new atomic-migration observability endpoints and CLI commands.


### PR DESCRIPTION
## Summary

- Closes #127 — adds a layered reproducibility story for EIF builds so upstream dep churn (yanked Cargo crates, moved GitHub repos, branch tips that drift) no longer breaks builds
- Three complementary layers, each opt-in independently: **pin** every flake input to a commit, **cache** built derivations via Cachix, **vendor** app sources into git
- New CLI surface: `enclave nixpkgs pin --latest|--check`, `enclave vendor`, `enclave build --push-cache`

## Why

Concrete failure that motivated this: [BitspendPayment/MerlinWallet#26713072059](https://github.com/BitspendPayment/MerlinWallet/actions/runs/26713072059/job/78726730150) — a Cargo crate moved upstream → `cargoHash` resolution failed → EIF couldn't be rebuilt. Same failure mode hits any Nix-built EIF when a transitive source disappears or relocates.

For a security-sensitive system that pins PCR0, "rebuild byte-identically months later" must work regardless of upstream availability. The three layers cover different parts of the closure:

| Layer | Covers | When it kicks in |
|---|---|---|
| **Pin** | Operator's yaml inputs + framework Nix inputs | Always (with explicit pin) or default branch reference |
| **Cache** | All built derivations (runtime, nixpkgs, app) | Rebuilds — once cache is populated |
| **Vendor** | App source deps (Cargo crates, Go modules) | First build too — no cache needed |

A complete defense stack uses all three. Each works alone for the failure mode it covers.

## What changed

### Layer 1: pin every flake input to a commit

- New `nix.nixpkgs_rev` + `nix.nixpkgs_hash` fields in `enclave.yaml` for operator-managed nixpkgs pinning
- `aws-nitro-util.url` and `flake-utils.url` pinned to commit SHAs (framework-managed constants `AwsNitroUtilRef` / `FlakeUtilsRef`)
- `inputs.<dep>.inputs.<sub>.follows` declarations collapse transitive flake inputs onto top-level pins
- Operators commit `enclave/flake.lock` as defense-in-depth for any future transitive inputs

### Layer 2: Cachix binary cache

- New `nix.substituters` + `nix.trusted_public_keys` fields in `enclave.yaml`
- Cachix-only by validation — non-`*.cachix.org` URLs rejected at config load
- `enclave build --push-cache` shells out to `cachix push <name> .enclave/result` after a successful build
- Scaffolded `build-eif.yml` + `deploy-enclave.yml` include a `Setup Cachix` step gated on `vars.CACHIX_CACHE_NAME` + `secrets.CACHIX_AUTH_TOKEN`

### Layer 3: optional app-source vendoring (Rust + Go)

- New `app.vendor: bool` field in `enclave.yaml` (default `false`)
- Flake template conditional: `cargoVendorDir = "vendor"` for Rust / `vendorHash = null` for Go when on
- `enclave vendor --path <dir>` shells out to `cargo vendor` or `go mod vendor`, respects `nix_subdir`
- Validation: `app.vendor: true` requires `language ∈ {rust, go}`; mutually exclusive with `nix_vendor_hash`
- `enclave setup` recognises `vendor: true` and skips the vendor-hash-discovery step (required for the recovery scenario)

## New CLI commands

| Command | Purpose |
|---|---|
| `enclave nixpkgs pin --latest [--branch <branch>]` | Fetch tip of branch, write SHA + SRI hash to `enclave.yaml`, rewrite `enclave/flake.nix`'s `nixpkgs.url` |
| `enclave nixpkgs pin --check` | Validate the existing pin without network |
| `enclave vendor --path <app-repo>` | Run `cargo vendor` / `go mod vendor` based on `app.language` |
| `enclave build --push-cache` | After successful build, push closure to first Cachix substituter |

## Operator workflow (vendor mode)

Order matters — flip `vendor: true` BEFORE running `enclave setup`, otherwise setup tries a trial Nix build that needs upstream (defeating the recovery purpose):

```sh
# In the app repo:
enclave vendor --path .
git add vendor/ && git commit && git push

# Edit enclave/enclave.yaml: set app.vendor: true, clear app.nix_vendor_hash
enclave setup           # skips hash discovery in vendor mode
enclave build           # uses committed vendor/
```

## Validation added

- `nix.substituters` entries must be `https://<name>.cachix.org` (no path, query, fragment); requires `trusted_public_keys` set
- `nix.nixpkgs_rev` + `nix.nixpkgs_hash` must be set together; rev = 40-char hex, hash starts with `sha256-`
- `app.vendor: true` requires `language ∈ {go, rust}`
- `app.vendor: true` is mutually exclusive with `app.nix_vendor_hash`

## Test plan

- [x] `go test ./cli/...` — full suite green (only pre-existing `TestCLI_Build` skipped, upstream-Nix issue unrelated)
- [x] Unit tests added: validation matrices, build-config field round-trip, surgical yaml/flake rewrite preservation, framework placeholder substitution across all 4 languages, vendor command routing
- [ ] Manual end-to-end: `enclave nixpkgs pin --latest` + `enclave build --push-cache` against a real Cachix cache; verify cache hit on rebuild
- [ ] Manual end-to-end: vendor a Rust project, flip `vendor: true`, build offline (`unshare -n enclave build`); verify PCR0 matches a fetch-mode build of the same commit

## Out of scope (follow-ups)

- Non-Cachix substituter backends (S3, Attic, self-hosted)
- GitHub Pages-hosted cache (researched; per-file 100 MB git push cap blocks it for typical Rust EIFs)
- `nix build --rebuild --check` in CI to detect non-determinism
- Vendor support for Node (no clean mode in `buildNpmPackage`) and .NET (`nugetDeps` already manifest-pinned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
