### PR TITLE
feat(runtime): automate attested blue-green migrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,13 +130,12 @@ interfaces are documented under [Deployment](#deployment).
 | vsock CID 3:1024 | enclave to host | gvproxy L2 network |
 | vsock CID 3:8002 | enclave to host | IMDS forwarding |
 | vsock CID 3:9000 | EIF init to host | boot heartbeat |
-| vsock :8003 | host to enclave | migration control HTTP |
 | TCP :443 | public to enclave | TLS, runtime API, application proxy |
 | TCP 127.0.0.1:8080 | inside enclave | internal runtime API |
 | TCP 127.0.0.1:7074 | inside enclave | the application |
 
-The migration control API has no application-level authentication. The host must
-expose vsock port 8003 only through a restricted operator control plane.
+Migration has no control endpoint. It runs over SSM between the enclaves
+themselves, so there is no inbound surface to authenticate or restrict.
 
 ### State model
 
@@ -162,18 +161,27 @@ under a KMS key that only the measured enclave can use.
 
 ### Boot paths
 
-On startup the runtime reads SSM and selects one of three paths, or fails.
+Every enclave boots into **candidate**: NSM, attestation and the migration
+control path are up, but there is no canonical state, no static secrets and no
+application. It leaves candidate only by obtaining state. A genesis or resuming
+enclave passes through in a single SSM read; a successor stays until its
+predecessor commits.
 
 | Condition | Path | Behaviour |
 |---|---|---|
-| `KMSKeyID/<pcr0>` absent, empty, or `UNSET`, and `ENCLAVE_PREVIOUS_PCR0=genesis` | genesis | Requires no predecessor artifacts. Creates the key, generates the DEK and secrets, writes a state-origin receipt, then commits `KMSKeyID/<pcr0>`. |
 | `KMSKeyID/<pcr0>` present and a state-origin receipt exists for this PCR0 | resume | Verifies its own receipt, decrypts state, writes nothing. |
-| `KMSKeyID/<pcr0>` present, no receipt for this PCR0, but a migration transition receipt and predecessor artifacts exist | adopt | Verifies the predecessor's attestation, the PCR31 commitment to its own PCR0, the KMS key policy, and the transition receipt before decrypting. Then writes its own state-origin receipt. |
-| `KMSKeyID/<pcr0>` absent and `ENCLAVE_PREVIOUS_PCR0` names a predecessor | fatal | The predecessor has not finalised the handoff. The boot fails rather than falling through to genesis with fresh state. |
+| `KMSKeyID/<pcr0>` present, no receipt for this PCR0, but a migration transition receipt and predecessor artifacts exist | adopt | Verifies that the recorded predecessor is the one baked into its own measurement, that predecessor's attestation, the PCR31 commitment to its own PCR0, the KMS key policy, and the transition receipt before decrypting. Then writes its own state-origin receipt. |
+| `KMSKeyID/<pcr0>` absent and `ENCLAVE_PREVIOUS_PCR0=genesis` | genesis | Requires no predecessor artifacts. Creates the key, generates the DEK and secrets, writes a state-origin receipt, then commits `KMSKeyID/<pcr0>`. |
+| `KMSKeyID/<pcr0>` absent and `ENCLAVE_PREVIOUS_PCR0` names a predecessor | remains candidate | Waits, indefinitely, for that predecessor to commit to it. |
+
+A candidate serves a self-signed certificate so it stays observable, reports
+`status: "candidate"` on `/v1/enclave-info`, and answers `503` on `/health` and
+on any application path. It promotes in place when its commit pointer appears —
+no restart, and no action by the host.
 
 Boot order is fixed and every step is fatal: clock synchronisation against
 `/dev/ptp0`, networking, AWS clients, telemetry, attestation signer, HTTP
-servers, state establishment, PCR extension, migration control server, TLS, SSM
+servers, state establishment, PCR extension, TLS, SSM
 environment overlay, static secret export, then exec of the application.
 
 ## Nix API
@@ -233,7 +241,7 @@ measurement. A subset can be overridden at runtime from SSM.
 |---|---|---|
 | `ENCLAVE_DEPLOYMENT` | `dev` | First SSM path segment. The value `dev` disables COSE signature verification of attestation documents. See [Security notes](#security-notes). |
 | `ENCLAVE_APP_NAME` | `app` | Second SSM path segment. |
-| `ENCLAVE_PREVIOUS_PCR0` | none | Required. Either the literal `genesis`, or the predecessor's PCR0 when adopting migrated state. Unset fails the boot. |
+| `ENCLAVE_PREVIOUS_PCR0` | none | Required. Either the literal `genesis`, or the predecessor's PCR0 when adopting migrated state. Unset fails the boot. Measured and not SSM-overridable. |
 | `ENCLAVE_KMS_KEY_LOCKED` | `false` | When `true`, the KMS key policy omits the root recovery principal and the SSM namespace segment becomes `locked` instead of `unlocked`. |
 | `ENCLAVE_SECRETS_CONFIG` | empty | JSON array of managed static secrets. Schema below. |
 | `ENCLAVE_AWS_REGION` | `us-east-1` | Region for all AWS SDK clients. |
@@ -258,7 +266,7 @@ measurement. A subset can be overridden at runtime from SSM.
 
 | Variable | Default | Purpose |
 |---|---|---|
-| `ENCLAVE_MIGRATION_COOLDOWN` | `0` | Minimum interval between `/request-migration` and `/finalise-migration`. A negative or unparseable value fails the boot. |
+| `ENCLAVE_MIGRATION_COOLDOWN` | `0` | Minimum interval between a candidate's attestation being adopted and the handoff committing. The window in which an abort can be written. A negative or unparseable value fails the boot. |
 | `ENCLAVE_MIGRATION_INTENT_RETENTION` | `87600h` (10 years) | S3 Object Lock retention applied to each migration intent record. |
 
 ### Clock
@@ -372,6 +380,9 @@ With `D` = deployment, `A` = app name, `L` = `locked` or `unlocked`:
 | `/D/A/L/<secret>/Ciphertext/<keyID>` | runtime | Encrypted static secret. |
 | `/D/A/StateOriginReceipt/<keyID>/<pcr0>` | runtime | Attested proof of which enclave established this state. |
 | `/D/A/MigrationStateOriginReceipt/<keyID>` | runtime | Predecessor's attestation over the successor's state. |
+| `/D/A/MigrationChallenge/<sourcePCR0>` | runtime | Live challenge published by a predecessor, rotated every minute. |
+| `/D/A/SuccessorAttestation/<sourcePCR0>/<candidatePCR0>` | runtime | A candidate's attestation answering that challenge. Advanced tier. |
+| `/D/A/MigrationAbort/<sourcePCR0>` | operator | Naming the pending target PCR0 cancels the handoff during the cooldown. |
 | `/D/A/MigrationPreviousPCR0/<pcr0>` | runtime | Predecessor PCR0, written by the predecessor into its successor's scope. |
 | `/D/A/MigrationPreviousPCR0Attestation/<pcr0>` | runtime | Predecessor attestation after PCR31 commitment, same scoping. |
 
@@ -416,21 +427,6 @@ This is the endpoint advertised to the application through
 `ENCLAVE_PROXY_PORT`. It does not serve `/v1/enclave-info`, the `/enclave/*`
 endpoints, or the application proxy.
 
-### Migration control, vsock :8003
-
-The host must provide trusted operators with controlled access to this vsock
-listener. It has no application-level authentication and must not be exposed to
-untrusted networks.
-
-| Method | Path | Body | Purpose |
-|---|---|---|---|
-| POST | `/request-migration` | `{"action":"requested"\|"aborted","target_pcr0":"<96 hex>"}` | Records an attested, Object-Locked intent in S3. Returns migration status. |
-| POST | `/finalise-migration` | `{"new_pcr0":"<96 hex>"}` | Performs the handoff and flips `KMSKeyID`. |
-
-Status codes: `425` while the cooldown is active, `409` if no matching intent
-exists or it was aborted, `503` if the intent store is unavailable, `400` for a
-malformed body.
-
 ## Deployment
 
 This flake builds the EIF but does not provision or configure its host or AWS
@@ -446,8 +442,6 @@ interfaces.
 - Forward IMDS from host CID 3, vsock port 8002, to the host's instance metadata
   service so the runtime can obtain AWS credentials.
 - Answer the EIF boot heartbeat at host CID 3, vsock port 9000.
-- Expose the enclave's migration control listener on vsock port 8003 only to
-  trusted operators.
 - Route intended client traffic to the enclave's TLS listener, TCP port 443 by
   default.
 
@@ -487,8 +481,33 @@ the runtime refuse to finalise a handoff onto that PCR0.
 ## Blue/green migration
 
 Migration transfers state from a running enclave to a successor with a different
-PCR0. The successor must not boot before the predecessor has finalised: it would
-find no artifacts in its own PCR0 scope, and fail rather than start fresh.
+PCR0. The successor must already be running as a candidate: the predecessor
+derives its identity from a fresh attestation it produces, so a migration cannot
+be aimed at an image that does not exist.
+
+The protocol is autonomous and runs entirely over SSM between the two enclaves.
+There is no control endpoint, no request to send, and nowhere to name a
+successor. **Booting a candidate is the request.**
+
+```text
+predecessor                                candidate
+  publish challenge   ------------------>  read it
+  read answers        <------------------  publish attestation
+  verify, record Object-Locked intent
+  ... cooldown, abort window ...
+  commit KMSKeyID/<target>  ------------>  promote
+```
+
+This is the authority boundary. The host decides when a candidate exists and can
+stop one, but it cannot forge a measurement, replay an old answer, or write the
+commit pointer. What it can still choose is *which* image to run as a candidate.
+The predecessor verifies that the answering enclave is real, is measured for this
+deployment, and answered the challenge it published minutes ago; it cannot verify
+that the image is the one an operator intended.
+
+If two candidates answer the same challenge the predecessor records nothing and
+keeps serving: an ambiguous round is nobody's intent. Remove the extra candidate
+and the next round proceeds.
 
 Nothing here is reversible and nothing needs to be. The predecessor keeps its own
 key, ciphertexts, and commit pointer throughout, so if the successor turns out to
@@ -497,44 +516,47 @@ rollback path because there is nothing to roll back.
 
 The order is:
 
-1. Build the successor EIF and read its PCR0. Its
-   `ENCLAVE_PREVIOUS_PCR0` must be set to the predecessor's PCR0, so the
-   predecessor measurement is an input to the successor build.
-2. Prepare the successor host and routing, but do not boot the successor.
-3. Request the migration against the predecessor:
-   ```sh
-     curl -fsS -H 'Content-Type: application/json' \
-       --data '{"action":"requested","target_pcr0":"<successor PCR0>"}' \
-     http://<migration-control-endpoint>/request-migration
-   ```
-   This writes an Object-Locked record to the intent log. It cannot be deleted.
-4. Wait for the cooldown. Poll `/v1/enclave-info` until
-   `migration.state == "eligible"`.
-5. Finalise:
-   ```sh
-     curl -fsS -H 'Content-Type: application/json' \
-       --data '{"new_pcr0":"<successor PCR0>"}' \
-     http://<migration-control-endpoint>/finalise-migration
-   ```
-   The predecessor commits the successor's PCR0 into its own PCR31, creates a
-   KMS key admitting the successor's PCR0 alone, re-encrypts the DEK and every
+1. Build the successor EIF with `ENCLAVE_PREVIOUS_PCR0` set to the
+   predecessor's PCR0, so the successor's own measurement commits to the
+   enclave it will adopt from.
+2. Boot the successor. It comes up as a candidate: it holds no state, serves no
+   application, and answers any challenge it finds under
+   `/<deployment>/<app>/MigrationChallenge/`.
+3. The predecessor adopts it. It verifies the document's signature and chain,
+   that its nonce is the challenge it published, and that its `user_data` claims
+   this deployment; it then takes the target PCR0 **from the document** and
+   writes an Object-Locked record to the intent log.
+
+   Confirm it is the successor you meant: `/v1/enclave-info` on the predecessor
+   reports `migration.target_pcr0`. The candidate reports the same handoff as
+   `candidate.awaiting_handoff_from` — informational only, since the intent log
+   is host-writable.
+4. The cooldown runs. This is the abort window: writing the pending target PCR0
+   to `/<deployment>/<app>/MigrationAbort/<predecessor PCR0>` cancels the
+   handoff. It is the only operator control in the protocol.
+5. The predecessor commits, on its own, once the intent is eligible and no abort
+   names the target. It commits the successor's PCR0 into its own PCR31, creates
+   a KMS key admitting the successor's PCR0 alone, re-encrypts the DEK and every
    static secret under it, writes its post-PCR31 attestation and the transition
    receipt, then writes `KMSKeyID/<successor PCR0>` last.
 
-   Finalising is not idempotent by design. If `KMSKeyID/<successor PCR0>`
-   already holds a value the request is refused with `409`, so a retry can never
-   mint a second key and displace a generation the successor may already be
-   running.
+   Committing is not a no-op if repeated: a second run would mint another key and
+   try to repoint the successor at it. The final `KMSKeyID` write is therefore an
+   atomic create-only SSM operation. When predecessor replicas race, exactly one
+   can commit; every loser observes an already-finalised migration and cannot
+   displace the generation the successor may already be running.
 6. Confirm `KMSKeyID/<successor PCR0>` now exists, and that
    `KMSKeyID/<predecessor PCR0>` is unchanged. The first is the commit; the
    second is the guarantee that the predecessor is still intact.
-7. Boot the successor. It verifies the predecessor attestation, the PCR31
-   commitment, the key policy, and the transition receipt before adopting the
-   state.
-8. Confirm adoption on the successor's `/v1/enclave-info`:
-   `previous_pcr0` equals the predecessor PCR0,
-   `previous_pcr0_attestation` is non-empty, and `migration.source_pcr0` equals
-   the successor's own PCR0.
+7. The successor promotes itself. It notices its commit pointer, checks that the
+   recorded predecessor matches the PCR0 baked into its own measurement, verifies
+   that predecessor's attestation, the PCR31 commitment to its own PCR0, the key
+   policy and the transition receipt, then adopts the state — in the same
+   process, without a restart and without the host doing anything.
+8. Confirm adoption on the successor's `/v1/enclave-info`: `status` is `ready`,
+    `previous_pcr0` equals the predecessor PCR0,
+    `previous_pcr0_attestation` is non-empty, and `migration.source_pcr0` equals
+    the successor's own PCR0.
 9. Shift client traffic using the deployment system's normal routing mechanism.
 10. Keep both enclaves healthy for the soak period, then retire the predecessor.
     Its key and SSM generation stay live; leave them alone unless you are certain
@@ -738,7 +760,7 @@ curl -fsS http://169.254.169.254/latest/meta-data/
 application process started. Check an application endpoint directly and read the
 enclave console for application errors.
 
-**`/request-migration` returns an empty reply under QEMU.** `vhost-device-vsock`
+**Migration stalls under QEMU.** `vhost-device-vsock`
 0.3 occasionally drops a forwarded host-to-guest connection before it reaches
 the enclave. Retry. This affects the emulated transport only; production uses
 Nitro AF_VSOCK. A genuine validation failure returns an HTTP status and body and
@@ -778,3 +800,18 @@ does not yield the state.
 so a successor enclave cannot silently substitute a different value; migration
 carries the ciphertexts forward under a key admitting the successor's
 measurement alone.
+
+**Migration authority rests on a live attestation, not on a supplied name.** The
+predecessor derives the successor's PCR0 from a Nitro document that answers a
+challenge it issued seconds earlier, so the host cannot invent a measurement and
+cannot replay an old one. What this does **not** establish is that the answering
+image is the one an operator authorised: a PCR0 cannot be inverted to learn what
+an image was built for, so the check binds the successor to this deployment and
+to liveness, not to a specific approved build. Closing that gap would need an
+external trust root — an operator-signed successor statement — which the runtime
+deliberately does not have.
+
+**The e2e test cannot validate this.** `ENCLAVE_DEV=true`, which the test
+harness sets, makes the runtime skip COSE signature verification entirely. A
+forged document passes there. The attestation checks are covered only by the Go
+unit tests, against a real test signer.

--- a/nix/tests/default.nix
+++ b/nix/tests/default.nix
@@ -258,19 +258,6 @@ let
         };
       };
 
-      systemd.services.migration-proxy = {
-        description = "Migration control proxy";
-        wantedBy = [ "multi-user.target" ];
-        after = [ "network-online.target" ];
-        wants = [ "network-online.target" ];
-        serviceConfig = {
-          Type = "simple";
-          ExecStart = "${pkgs.socat}/bin/socat TCP-LISTEN:8003,bind=127.0.0.1,fork,reuseaddr VSOCK-CONNECT:1:8003";
-          Restart = "always";
-          RestartSec = 5;
-        };
-      };
-
       systemd.services.mock-imds-forward = {
         description = "Test IMDS endpoint";
         wantedBy = [ "multi-user.target" ];

--- a/nix/tests/e2e.py
+++ b/nix/tests/e2e.py
@@ -73,14 +73,14 @@ def print_enclave_diagnostics(node):
     print(
         node.execute(
             "systemctl status vhost-device-vsock enclave-heartbeat gvproxy "
-            "imds-proxy migration-proxy mock-imds-forward enclave-start "
+            "imds-proxy mock-imds-forward enclave-start "
             "--no-pager 2>&1"
         )[1]
     )
     print(
         node.execute(
             "journalctl -u vhost-device-vsock -u enclave-heartbeat -u gvproxy "
-            "-u imds-proxy -u migration-proxy -u mock-imds-forward "
+            "-u imds-proxy -u mock-imds-forward "
             "-u enclave-start --no-pager -n 150 2>&1"
         )[1]
     )
@@ -199,7 +199,7 @@ assert "WARNING" in out, out
 
 genesis_key = get_param(key_param(BLUE_PCR0))
 assert genesis_key not in ("", "UNSET", "None")
-# Green's commit pointer is created by blue at finalise; it must not exist yet.
+# Green's commit pointer is created by blue when it commits; not yet.
 assert get_param(key_param(GREEN_PCR0)) == ""
 
 # Exercise both the hard-step and PI-servo paths against the real /dev/ptp0.
@@ -288,31 +288,43 @@ assert hardsteps_after_sub == hardsteps_before_sub, (
 )
 wait_healthy(blue)
 
-# Green remains off until blue has atomically committed the handoff.
-migration_request_output = ""
-for _ in range(30):
-    migration_status, migration_request_output = blue.execute(
-        "rm -f /tmp/request-migration.json; "
-        "curl --fail-with-body -sS -H 'Content-Type: application/json' "
-        f"--data '{{\"action\":\"requested\",\"target_pcr0\":\"{GREEN_PCR0}\"}}' "
-        "--output /tmp/request-migration.json "
-        "http://127.0.0.1:8003/request-migration"
-    )
-    valid_status, _ = blue.execute(
-        f"jq -e --arg p '{GREEN_PCR0}' "
-        "'.target_pcr0 == $p and "
-        "(.state == \"cooling_down\" or .state == \"eligible\")' "
-        "/tmp/request-migration.json"
-    )
-    if migration_status == 0 and valid_status == 0:
-        break
-    time.sleep(1)
-else:
-    print(migration_request_output)
-    print(blue.execute("cat /tmp/request-migration.json 2>/dev/null || true")[1])
-    print_enclave_diagnostics(blue)
-    raise Exception("request-migration did not succeed")
+# ACME settings are read when TLS is configured. Blue is already up and stays
+# self-signed; green picks these up when it promotes.
+put_env("ENCLAVE_NITRIDING_USE_ACME", "true")
+put_env("ENCLAVE_NITRIDING_ACME_DIRECTORY", f"https://{AWS_NODE_IP}:14000/dir")
+put_env("ENCLAVE_NITRIDING_ACME_EMAIL", f"acme-test@{FQDN}")
+put_env("ENCLAVE_NITRIDING_ACME_CA", aws.succeed("cat /etc/pebble/ca.crt"))
 
+# Booting a candidate is the whole trigger: there is no admin endpoint and no
+# request to send. Blue publishes a challenge over SSM, green answers it, and
+# blue commits once the cooldown elapses.
+green.start()
+green.wait_for_unit("multi-user.target")
+green.wait_for_unit("mock-imds-forward.service")
+green.wait_until_succeeds("curl -fsS http://169.254.169.254/health")
+green.wait_for_unit("enclave-start.service")
+
+# A candidate holds no canonical state and serves no application.
+green.wait_until_succeeds(
+    "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
+    "| jq -e '.status == \"candidate\"'",
+    timeout=180,
+)
+health_status, _ = green.execute("curl -skf --http1.1 https://127.0.0.1/health")
+assert health_status != 0, "a candidate must not report healthy"
+secret_status, _ = green.execute(
+    "curl -skf --http1.1 https://127.0.0.1/test/env/E2E_SIGNING_KEY"
+)
+assert secret_status != 0, "a candidate must serve no application request"
+assert get_param(key_param(GREEN_PCR0)) == ""
+
+# Blue records an intent naming green, derived from green's attestation. No
+# operator wrote that PCR0 anywhere.
+blue.wait_until_succeeds(
+    "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
+    f"| jq -e --arg p '{GREEN_PCR0}' '.migration.target_pcr0 == $p'",
+    timeout=180,
+)
 assert (
     int(
         cloud(
@@ -322,58 +334,32 @@ assert (
     )
     >= 1
 )
-blue.wait_until_succeeds(
+
+# Green can see who is offering it the handoff, while still a candidate.
+green.wait_until_succeeds(
     "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
-    "| jq -e '.migration.state == \"eligible\"'",
+    f"| jq -e --arg b '{BLUE_PCR0}' "
+    "'.candidate.awaiting_handoff_from == $b'",
     timeout=120,
 )
 
-finalise_response_valid = False
+# Blue commits on its own once eligible.
 migration_key = ""
-finalise_output = ""
-committed = False
-for attempt in range(30):
-    if not committed:
-        finalise_status, finalise_output = blue.execute(
-            "rm -f /tmp/finalise-migration.json; "
-            "curl --fail-with-body -sS -H 'Content-Type: application/json' "
-            f"--data '{{\"new_pcr0\":\"{GREEN_PCR0}\"}}' "
-            "--output /tmp/finalise-migration.json "
-            "http://127.0.0.1:8003/finalise-migration"
-        )
-        response_status, _ = blue.execute(
-            f"jq -e --arg p '{BLUE_PCR0}' "
-            "'.pcr0 == $p and (.exported | index(\"e2e-signing-key\"))' "
-            "/tmp/finalise-migration.json"
-        )
-        if finalise_status == 0 and response_status == 0:
-            finalise_response_valid = True
-        # Finalising is not idempotent: once it commits, a retry is a 409. Stop
-        # POSTing and just wait for the pointer to be readable.
-        committed = finalise_status == 0
-    if committed or attempt % 3 == 2:
-        migration_key = get_param(key_param(GREEN_PCR0))
-        if migration_key != "":
-            break
+for _ in range(120):
+    migration_key = get_param(key_param(GREEN_PCR0))
+    if migration_key not in ("", "UNSET", "None"):
+        break
     time.sleep(1)
 else:
-    print(finalise_output)
-    print(blue.execute("cat /tmp/finalise-migration.json 2>/dev/null || true")[1])
     print_enclave_diagnostics(blue)
-    raise Exception("finalise-migration did not commit")
+    raise Exception("blue did not commit the handoff")
 
-if finalise_response_valid:
-    blue.succeed(
-        f"jq -e --arg p '{BLUE_PCR0}' "
-        "'.pcr0 == $p and (.exported | index(\"e2e-signing-key\"))' "
-        "/tmp/finalise-migration.json"
-    )
-assert migration_key not in ("", "UNSET", "None")
 assert migration_key != genesis_key
+
 # The handoff writes only into green's scope: blue's pointer is untouched, which
 # is what lets blue keep serving and reboot without any rollback machinery.
 assert get_param(key_param(BLUE_PCR0)) == genesis_key
-# Blue is genesis-born, so its own lineage is unchanged by having finalised.
+# Blue is genesis-born, so its own lineage is unchanged by handing off.
 blue.succeed(
     "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
     "| jq -e '.previous_pcr0 == \"genesis\"'"
@@ -390,18 +376,14 @@ aws.succeed(
     "| . == [$g]' /tmp/migration-key-policy.json"
 )
 
-# ACME settings are loaded once at boot, so blue remains self-signed.
-put_env("ENCLAVE_NITRIDING_USE_ACME", "true")
-put_env("ENCLAVE_NITRIDING_ACME_DIRECTORY", f"https://{AWS_NODE_IP}:14000/dir")
-put_env("ENCLAVE_NITRIDING_ACME_EMAIL", f"acme-test@{FQDN}")
-put_env("ENCLAVE_NITRIDING_ACME_CA", aws.succeed("cat /etc/pebble/ca.crt"))
-
-green.start()
-green.wait_for_unit("multi-user.target")
-green.wait_for_unit("mock-imds-forward.service")
-green.wait_until_succeeds("curl -fsS http://169.254.169.254/health")
-green.wait_for_unit("enclave-start.service")
+# Green promotes in-process the moment blue commits: no restart, and the host
+# does nothing. Its real TLS configuration is applied at that point.
 wait_healthy(green)
+green.wait_until_succeeds(
+    "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
+    "| jq -e '.status == \"ready\"'",
+    timeout=180,
+)
 assert secret_value(green) == blue_secret
 green.succeed(
     "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "

--- a/runtime/environment.go
+++ b/runtime/environment.go
@@ -295,3 +295,40 @@ func envOr(key, fallback string) string {
 	}
 	return fallback
 }
+
+// migrationChallengeParam: the live challenge published by a predecessor.
+func migrationChallengeParam(sourcePCR0 string) string {
+	return migrationChallengePrefix() + strings.ToLower(sourcePCR0)
+}
+
+func migrationChallengePrefix() string {
+	return fmt.Sprintf("/%s/%s/MigrationChallenge/", getDeployment(), getAppName())
+}
+
+// successorAttestationParam: a candidate's answer to sourcePCR0's challenge.
+// Advanced tier: an attestation document exceeds the 4 KB Standard-tier limit.
+func successorAttestationParam(sourcePCR0, candidatePCR0 string) string {
+	return successorAttestationPrefix(sourcePCR0) + strings.ToLower(candidatePCR0)
+}
+
+// successorAttestationPrefix: the answers to one predecessor's challenge. Its
+// children are one level deep, so ListParams enumerates the candidates.
+func successorAttestationPrefix(sourcePCR0 string) string {
+	return fmt.Sprintf(
+		"/%s/%s/SuccessorAttestation/%s/",
+		getDeployment(),
+		getAppName(),
+		strings.ToLower(sourcePCR0),
+	)
+}
+
+// migrationAbortParam: operator-written. Naming the pending target PCR0 stops the
+// handoff before it commits. This is the only operator control in the protocol.
+func migrationAbortParam(sourcePCR0 string) string {
+	return fmt.Sprintf(
+		"/%s/%s/MigrationAbort/%s",
+		getDeployment(),
+		getAppName(),
+		strings.ToLower(sourcePCR0),
+	)
+}

--- a/runtime/migrate.go
+++ b/runtime/migrate.go
@@ -1,22 +1,41 @@
 package runtime
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"math"
+	"strings"
 	"sync"
 	"time"
+
+	"github.com/fxamacker/cbor/v2"
 )
 
 // migrationPCRIndex stores the successor-PCR0 handoff commitment.
-const migrationPCRIndex = 31
+const (
+	migrationPCRIndex        = 31
+	migrationPollInterval    = 5 * time.Second
+	migrationChallengeRotate = time.Minute
+	successorClaimSchemaV1   = "enclave.successor_claim.v1"
+)
 
-type MigrationRequest struct {
-	Action     string `json:"action"`
-	TargetPCR0 string `json:"target_pcr0,omitempty"`
+// successorClaimV1 is the attested pre-image a candidate offers. Deployment is
+// measured and not SSM-overridable, so it binds the claim to one deployment and
+// a document produced for another is rejected.
+type successorClaimV1 struct {
+	Schema     string `cbor:"schema"`
+	Deployment string `cbor:"deployment"`
+}
+
+// CandidateInfo is reported by an enclave still awaiting a handoff.
+type CandidateInfo struct {
+	AwaitingHandoffFrom string     `json:"awaiting_handoff_from,omitempty"`
+	RequestedAt         *time.Time `json:"requested_at,omitempty"`
 }
 
 type CompleteMigrationResult struct {
@@ -48,13 +67,17 @@ const (
 )
 
 type Migrator interface {
-	HandleMigrationRequest(
-		ctx context.Context,
-		action, targetPCR0 string,
-	) (*MigrationStatus, error)
-	CompleteMigration(ctx context.Context) (*CompleteMigrationResult, error)
+	// RunMigrationControl drives the predecessor half, for the life of a
+	// serving enclave.
+	RunMigrationControl(ctx context.Context)
+	// RunCandidateAttestation drives the candidate half, until promotion.
+	RunCandidateAttestation(ctx context.Context)
+
 	PreviousPCR0Info(ctx context.Context) (*PreviousPCR0Info, error)
 	MigrationStatus(ctx context.Context) (*MigrationStatus, error)
+	CandidateInfo(ctx context.Context) (*CandidateInfo, error)
+	Ready() bool
+	Promote(kms PrimaryKMS, dek DEK, secrets []StaticSecret)
 }
 
 type migrator struct {
@@ -65,29 +88,41 @@ type migrator struct {
 	dek           DEK
 	staticSecrets []StaticSecret
 	intent        *migrationIntentLog
+	ready         bool
+
+	challenge   []byte
+	challengeAt time.Time
 }
 
+// NewMigrator builds the candidate half: enough to attest identity, answer a
+// challenge and read the intent log, which is all an enclave can do before it
+// holds state. Promote supplies the rest once state is established.
 func NewMigrator(
 	nsm NSM,
-	kms PrimaryKMS,
 	ssm SSM,
 	s3 S3API,
-	dek DEK,
-	secrets []StaticSecret,
 	migrationIntentBucketName string,
 ) (Migrator, error) {
-	intent, err := newMigrationIntentLog(s3, nsm, migrationIntentBucketName)
+	m, err := newMigrator(nsm, ssm, s3, migrationIntentBucketName)
 	if err != nil {
 		return nil, err
 	}
-	return &migrator{
-		nsm:           nsm,
-		kms:           kms,
-		ssm:           ssm,
-		dek:           dek,
-		staticSecrets: secrets,
-		intent:        intent,
-	}, nil
+	return m, nil
+}
+
+func (m *migrator) Promote(kms PrimaryKMS, dek DEK, secrets []StaticSecret) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.kms = kms
+	m.dek = dek
+	m.staticSecrets = secrets
+	m.ready = true
+}
+
+func (m *migrator) Ready() bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.ready
 }
 
 func (m *migrator) PreviousPCR0Info(ctx context.Context) (*PreviousPCR0Info, error) {
@@ -113,31 +148,22 @@ func (m *migrator) PreviousPCR0Info(ctx context.Context) (*PreviousPCR0Info, err
 	return &PreviousPCR0Info{PCR0: pcr0, Attestation: attest}, nil
 }
 
-func (m *migrator) HandleMigrationRequest(
-	ctx context.Context,
-	action, targetPCR0 string,
-) (*MigrationStatus, error) {
-	cooldown, err := getMigrationCooldown()
+func (m *migrator) CandidateInfo(ctx context.Context) (*CandidateInfo, error) {
+	own, err := m.nsm.PCR0()
 	if err != nil {
+		return nil, fmt.Errorf("could not read own PCR0 from NSM: %w", err)
+	}
+
+	inbound, err := m.intent.InboundIntent(ctx, hex.EncodeToString(own))
+	if err != nil || inbound == nil {
 		return nil, err
 	}
 
-	m.mu.Lock()
-	defer m.mu.Unlock()
-
-	var intentHead *migrationIntent
-	switch action {
-	case migrationIntentRequested:
-		intentHead, err = m.intent.Request(ctx, targetPCR0)
-	case migrationIntentAborted:
-		intentHead, err = m.intent.Abort(ctx)
-	default:
-		return nil, fmt.Errorf("unknown migration action %q", action)
-	}
-	if err != nil {
-		return nil, err
-	}
-	return migrationStatusAt(intentHead, cooldown, time.Now()), nil
+	publishedAt := inbound.PublishedAt
+	return &CandidateInfo{
+		AwaitingHandoffFrom: inbound.SourcePCR0,
+		RequestedAt:         &publishedAt,
+	}, nil
 }
 
 func (m *migrator) MigrationStatus(ctx context.Context) (*MigrationStatus, error) {
@@ -157,45 +183,6 @@ func (m *migrator) MigrationStatus(ctx context.Context) (*MigrationStatus, error
 		}
 	}
 	return status, nil
-}
-
-func migrationStatusAt(
-	head *migrationIntent,
-	cooldown time.Duration,
-	now time.Time,
-) *MigrationStatus {
-	if head == nil {
-		return &MigrationStatus{State: migrationStateNone}
-	}
-	publishedAt := head.PublishedAt
-	status := &MigrationStatus{
-		SourcePCR0:  head.SourcePCR0,
-		TargetPCR0:  head.TargetPCR0,
-		Sequence:    head.Sequence,
-		Action:      head.Action,
-		PublishedAt: &publishedAt,
-	}
-	if head.Action == migrationIntentAborted {
-		status.State = migrationStateAborted
-		return status
-	}
-
-	if cooldown == 0 {
-		status.State = migrationStateEligible
-		status.EligibleAt = &head.PublishedAt
-		return status
-	}
-
-	eligibleAt := head.PublishedAt.Add(cooldown)
-	status.EligibleAt = &eligibleAt
-	remaining := eligibleAt.Sub(now)
-	if remaining <= 0 {
-		status.State = migrationStateEligible
-		return status
-	}
-	status.State = migrationStateCoolingDown
-	status.RemainingSeconds = int(math.Ceil(remaining.Seconds()))
-	return status
 }
 
 // CompleteMigration exports state under a PCR0-locked migration key, then flips KMSKeyID.
@@ -335,10 +322,23 @@ func (m *migrator) CompleteMigration(
 		)
 	}
 
-	// Atomic commit: from here, the successor boots on the migration key.
-	if err := m.ssm.Set(ctx, kmsKeyIDParam(targetPCR0), migrationKMS.KeyID()); err != nil {
+	// Atomic commit: SSM's create-only write elects exactly one predecessor when
+	// independent replicas race to hand state to the same successor.
+	created, err := m.ssm.SetIfAbsent(
+		ctx,
+		kmsKeyIDParam(targetPCR0),
+		migrationKMS.KeyID(),
+	)
+	if err != nil {
 		return nil, fmt.Errorf(
 			"failed to commit successor KMS key ID: %w", err,
+		)
+	}
+	if !created {
+		return nil, fmt.Errorf(
+			"%w: %s already has a committed generation",
+			errMigrationAlreadyFinalised,
+			kmsKeyIDParam(targetPCR0),
 		)
 	}
 
@@ -354,16 +354,423 @@ func (m *migrator) CompleteMigration(
 	}, nil
 }
 
-func (r MigrationRequest) Validate() error {
-	switch r.Action {
-	case migrationIntentRequested:
-		if _, _, err := normalizePCR0(r.TargetPCR0); err != nil {
-			return fmt.Errorf("target_pcr0 %w", err)
+// The migration control plane is autonomous and lives entirely in SSM. There is
+// no admin endpoint, and no channel through which a host can name a successor.
+//
+//	predecessor                              candidate
+//	  publish challenge  -------------->  read it
+//	  read answers       <--------------  publish attestation
+//	  verify, record intent
+//	  ... cooldown ...
+//	  commit KMSKeyID/<target>  ------->  promote
+//
+
+func (m *migrator) RunMigrationControl(ctx context.Context) {
+	ticker := time.NewTicker(migrationPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if err := m.advanceMigration(ctx); err != nil &&
+			!errors.Is(err, errMigrationIntentAbsent) {
+			// Nothing here is fatal: a serving enclave keeps serving whether or
+			// not a handoff can proceed.
+			slog.Warn("migration control", "error", err)
 		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+// RunCandidateAttestation drives the candidate half: answer every published
+// challenge so a predecessor can discover this enclave and prove what it is.
+func (m *migrator) RunCandidateAttestation(ctx context.Context) {
+	ticker := time.NewTicker(migrationPollInterval)
+	defer ticker.Stop()
+
+	for {
+		if m.Ready() {
+			return
+		}
+
+		if err := m.answerChallenges(ctx); err != nil {
+			slog.Warn("candidate attestation", "error", err)
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func newMigrator(
+	nsm NSM,
+	ssm SSM,
+	s3 S3API,
+	migrationIntentBucketName string,
+) (*migrator, error) {
+	intent, err := newMigrationIntentLog(s3, nsm, migrationIntentBucketName)
+	if err != nil {
+		return nil, err
+	}
+	return &migrator{
+		nsm:    nsm,
+		ssm:    ssm,
+		intent: intent,
+	}, nil
+}
+
+func (m *migrator) issueMigrationChallenge() (string, error) {
+	challenge := make([]byte, 32)
+	if _, err := secureRandom(challenge); err != nil {
+		return "", fmt.Errorf("generate migration challenge: %w", err)
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.challenge = challenge
+	m.challengeAt = time.Now()
+
+	return hex.EncodeToString(challenge), nil
+}
+
+func (m *migrator) handleMigrationRequest(
+	ctx context.Context,
+	action, targetPCR0 string,
+) (*MigrationStatus, error) {
+	cooldown, err := getMigrationCooldown()
+	if err != nil {
+		return nil, err
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if !m.ready {
+		return nil, errMigrationCandidate
+	}
+
+	var intentHead *migrationIntent
+	switch action {
+	case migrationIntentRequested:
+		intentHead, err = m.intent.Request(ctx, targetPCR0)
+		if err != nil {
+			return nil, err
+		}
+		// One challenge, one intent: the next round mints a fresh nonce, which
+		// retires every answer to this one.
+		m.challenge = nil
 	case migrationIntentAborted:
-		return nil
+		intentHead, err = m.intent.Abort(ctx)
+		if err != nil {
+			return nil, err
+		}
 	default:
-		return fmt.Errorf("unknown migration action %q", r.Action)
+		return nil, fmt.Errorf("unknown migration action %q", action)
+	}
+
+	return migrationStatusAt(intentHead, cooldown, time.Now()), nil
+}
+
+func migrationStatusAt(
+	head *migrationIntent,
+	cooldown time.Duration,
+	now time.Time,
+) *MigrationStatus {
+	if head == nil {
+		return &MigrationStatus{State: migrationStateNone}
+	}
+	publishedAt := head.PublishedAt
+	status := &MigrationStatus{
+		SourcePCR0:  head.SourcePCR0,
+		TargetPCR0:  head.TargetPCR0,
+		Sequence:    head.Sequence,
+		Action:      head.Action,
+		PublishedAt: &publishedAt,
+	}
+	if head.Action == migrationIntentAborted {
+		status.State = migrationStateAborted
+		return status
+	}
+
+	if cooldown == 0 {
+		status.State = migrationStateEligible
+		status.EligibleAt = &head.PublishedAt
+		return status
+	}
+
+	eligibleAt := head.PublishedAt.Add(cooldown)
+	status.EligibleAt = &eligibleAt
+	remaining := eligibleAt.Sub(now)
+	if remaining <= 0 {
+		status.State = migrationStateEligible
+		return status
+	}
+	status.State = migrationStateCoolingDown
+	status.RemainingSeconds = int(math.Ceil(remaining.Seconds()))
+	return status
+}
+
+// advanceMigration moves the handoff one step: publish a challenge, adopt a
+// candidate's answer as an intent, or commit once the cooldown has elapsed.
+func (m *migrator) advanceMigration(ctx context.Context) error {
+	own, err := m.ownPCR0()
+	if err != nil {
+		return err
+	}
+
+	status, err := m.MigrationStatus(ctx)
+	if err != nil {
+		return err
+	}
+
+	switch status.State {
+	case migrationStateEligible:
+		return m.commitMigration(ctx, own, status)
+	case migrationStateCoolingDown:
+		return nil
+	}
+
+	// No intent, or the last one was aborted: keep a live challenge published and
+	// watch for an answer.
+	if err := m.publishChallenge(ctx, own); err != nil {
+		return err
+	}
+	return m.adoptCandidate(ctx, own)
+}
+
+// publishChallenge keeps a fresh nonce in SSM for candidates to answer. It
+// rotates so a long-dead answer cannot be presented later.
+func (m *migrator) publishChallenge(ctx context.Context, ownPCR0 string) error {
+	m.mu.Lock()
+	fresh := len(m.challenge) > 0 && time.Since(m.challengeAt) < migrationChallengeRotate
+	m.mu.Unlock()
+	if fresh {
+		return nil
+	}
+
+	challenge, err := m.issueMigrationChallenge()
+	if err != nil {
+		return err
+	}
+	if err := m.ssm.Set(ctx, migrationChallengeParam(ownPCR0), challenge); err != nil {
+		return fmt.Errorf("publish migration challenge: %w", err)
 	}
 	return nil
+}
+
+// adoptCandidate looks for a candidate that answered the live challenge and
+// records the Object-Locked intent naming it.
+func (m *migrator) adoptCandidate(ctx context.Context, ownPCR0 string) error {
+	answers, err := m.ssm.ListParams(ctx, successorAttestationPrefix(ownPCR0))
+	if err != nil {
+		return fmt.Errorf("list successor attestations: %w", err)
+	}
+	if len(answers) == 0 {
+		return nil
+	}
+
+	m.mu.Lock()
+	issued := append([]byte(nil), m.challenge...)
+	m.mu.Unlock()
+	if len(issued) == 0 {
+		return nil
+	}
+
+	// Verify every answer before choosing, so an unparseable one cannot mask a
+	// second valid candidate and make an ambiguous state look decided.
+	var targets []string
+	for _, answer := range answers {
+		target, err := m.verifySuccessorAttestation(answer.Value, issued)
+		if err != nil {
+			slog.Warn("ignoring successor attestation", "param", answer.Name, "error", err)
+			continue
+		}
+		if strings.EqualFold(target, ownPCR0) {
+			continue
+		}
+		targets = append(targets, target)
+	}
+
+	switch len(targets) {
+	case 0:
+		return nil
+	case 1:
+	default:
+		// Two live candidates means nobody knows which should win. Keep serving.
+		return fmt.Errorf(
+			"%w: %d candidates answered", errMigrationSuccessorAmbiguous, len(targets),
+		)
+	}
+
+	if _, err := m.handleMigrationRequest(ctx, migrationIntentRequested, targets[0]); err != nil {
+		return err
+	}
+
+	slog.Info("migration intent recorded from candidate attestation",
+		"target_pcr0", prefix16(targets[0]))
+	return nil
+}
+
+// commitMigration finalises once the cooldown has elapsed, unless an operator
+// has written an abort naming the pending target.
+func (m *migrator) commitMigration(
+	ctx context.Context,
+	ownPCR0 string,
+	status *MigrationStatus,
+) error {
+	abort, err := m.ssm.MayGet(ctx, migrationAbortParam(ownPCR0))
+	if err != nil {
+		return fmt.Errorf("read migration abort: %w", err)
+	}
+	if strings.EqualFold(strings.TrimSpace(abort), status.TargetPCR0) {
+		if _, err := m.handleMigrationRequest(ctx, migrationIntentAborted, ""); err != nil {
+			return err
+		}
+		slog.Warn("migration aborted by operator", "target_pcr0", prefix16(status.TargetPCR0))
+		return nil
+	}
+
+	res, err := m.CompleteMigration(ctx)
+	if errors.Is(err, errMigrationAlreadyFinalised) {
+		// The successor already holds a committed generation. Nothing to do.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+
+	slog.Info("migration committed", "from_pcr0", prefix16(res.PCR0),
+		"exported", len(res.Exported))
+	return nil
+}
+
+func (m *migrator) answerChallenges(ctx context.Context) error {
+	own, err := m.ownPCR0()
+	if err != nil {
+		return err
+	}
+
+	challenges, err := m.ssm.ListParams(ctx, migrationChallengePrefix())
+	if err != nil {
+		return fmt.Errorf("list migration challenges: %w", err)
+	}
+
+	for _, published := range challenges {
+		source := strings.TrimPrefix(published.Name, migrationChallengePrefix())
+		if source == "" || strings.EqualFold(source, own) {
+			continue
+		}
+
+		challenge, err := hex.DecodeString(strings.TrimSpace(published.Value))
+		if err != nil || len(challenge) == 0 {
+			continue
+		}
+
+		doc, err := m.buildSuccessorAttestation(challenge)
+		if err != nil {
+			return fmt.Errorf("attest successor claim: %w", err)
+		}
+
+		if err := m.ssm.Set(
+			ctx,
+			successorAttestationParam(source, own),
+			doc,
+			WithAdvancedTier(),
+		); err != nil {
+			return fmt.Errorf("publish successor attestation: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// buildSuccessorAttestation is the candidate side of migration initiation. The
+// challenge lands in the document's nonce, so the predecessor can tell a live
+// answer from a replayed one.
+func (m *migrator) buildSuccessorAttestation(challenge []byte) (string, error) {
+	if len(challenge) == 0 {
+		return "", fmt.Errorf("migration challenge is required")
+	}
+
+	payload, err := successorClaimPayload(getDeployment())
+	if err != nil {
+		return "", err
+	}
+
+	doc, _, err := m.nsm.BuildAttestationDocument(WithNonce(challenge), WithUserData(payload))
+	if err != nil {
+		return "", fmt.Errorf("attest successor claim: %w", err)
+	}
+
+	return base64.StdEncoding.EncodeToString(doc), nil
+}
+
+// verifySuccessorAttestation is the predecessor side. It returns the successor's
+// PCR0, taken from the verified document — the target is an output here, never
+// an input, which is the whole point of the exchange.
+func (m *migrator) verifySuccessorAttestation(docB64 string, challenge []byte) (string, error) {
+	if docB64 == "" {
+		return "", fmt.Errorf("successor attestation is required")
+	}
+	if len(challenge) == 0 {
+		return "", fmt.Errorf("migration challenge is required")
+	}
+
+	// Built from our own deployment, so a claim naming another one cannot match.
+	expected, err := successorClaimPayload(getDeployment())
+	if err != nil {
+		return "", err
+	}
+
+	// No expected PCRs: PCR0 is what we are here to learn. The signature and
+	// certificate chain establish that some real enclave produced this.
+	doc, err := m.nsm.VerifyAttestationDocument(docB64, nil, expected)
+	if err != nil {
+		return "", fmt.Errorf("verify successor attestation: %w", err)
+	}
+
+	if !bytes.Equal(doc.Document.Nonce, challenge) {
+		return "", fmt.Errorf("successor attestation does not answer the issued challenge")
+	}
+
+	pcr0, ok := doc.Document.PCRs[0]
+	if !ok {
+		return "", fmt.Errorf("successor attestation has no PCR0")
+	}
+
+	targetPCR0, _, err := normalizePCR0(hex.EncodeToString(pcr0))
+	if err != nil {
+		return "", fmt.Errorf("successor PCR0 %w", err)
+	}
+
+	return targetPCR0, nil
+}
+
+func (m *migrator) ownPCR0() (string, error) {
+	pcr0, err := m.nsm.PCR0()
+	if err != nil {
+		return "", fmt.Errorf("could not read own PCR0 from NSM: %w", err)
+	}
+	return hex.EncodeToString(pcr0), nil
+}
+
+func successorClaimPayload(deployment string) ([]byte, error) {
+	enc, err := cbor.CoreDetEncOptions().EncMode()
+	if err != nil {
+		return nil, fmt.Errorf("build canonical CBOR encoder: %w", err)
+	}
+	payload, err := enc.Marshal(successorClaimV1{
+		Schema:     successorClaimSchemaV1,
+		Deployment: deployment,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("serialize successor claim: %w", err)
+	}
+	return payload, nil
 }

--- a/runtime/migrate_test.go
+++ b/runtime/migrate_test.go
@@ -3,6 +3,7 @@ package runtime
 import (
 	"bytes"
 	"context"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
 	"errors"
@@ -10,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/fxamacker/cbor/v2"
 	"github.com/hf/nitrite"
 	"github.com/hf/nsm/request"
 	"github.com/hf/nsm/response"
@@ -62,6 +64,22 @@ func TestVerifyPredecessorCommitment_Predecessor(t *testing.T) {
 				predecessorAttestation: attestation,
 			},
 		)
+		require.Error(t, err)
+	})
+
+	t.Run("rejects an attestation from a different predecessor", func(t *testing.T) {
+		nsm := predecessorNSM(t, currentPCR0Bytes, verifyDocResult(map[uint][]byte{
+			0:                 bytes.Repeat([]byte{0x77}, 48),
+			migrationPCRIndex: pcrExtendFromZero(currentPCR0Bytes),
+		}, nil))
+
+		err := verifyPredecessorCommitment(nsm, unverifiedState{
+			startState:             startStateMigration,
+			currentPCR0:            currentPCR0Bytes,
+			predecessorPCR0:        prevPCR0,
+			predecessorAttestation: attestation,
+		})
+
 		require.Error(t, err)
 	})
 
@@ -130,8 +148,8 @@ func TestMigratorPreviousPCR0Info(t *testing.T) {
 
 	t.Run("genesis", func(t *testing.T) {
 		m, err := NewMigrator(
-			kmsTestNSMWithPCR0(t, infoPCR0Bytes), nil, NewSSM(&fakeSSM{}),
-			newFakeS3(), nil, nil, migrationIntentTestBucket,
+			kmsTestNSMWithPCR0(t, infoPCR0Bytes), NewSSM(&fakeSSM{}),
+			newFakeS3(), migrationIntentTestBucket,
 		)
 		require.NoError(t, err)
 		info, err := m.PreviousPCR0Info(ctx)
@@ -142,10 +160,10 @@ func TestMigratorPreviousPCR0Info(t *testing.T) {
 
 	t.Run("recorded predecessor", func(t *testing.T) {
 		m, err := NewMigrator(
-			kmsTestNSMWithPCR0(t, infoPCR0Bytes), nil, NewSSM(&fakeSSM{params: map[string]string{
+			kmsTestNSMWithPCR0(t, infoPCR0Bytes), NewSSM(&fakeSSM{params: map[string]string{
 				migrationPreviousPCR0Param(infoPCR0):            "abc123",
 				migrationPreviousPCR0AttestationParam(infoPCR0): "attestation",
-			}}), newFakeS3(), nil, nil, migrationIntentTestBucket)
+			}}), newFakeS3(), migrationIntentTestBucket)
 		require.NoError(t, err)
 		info, err := m.PreviousPCR0Info(ctx)
 
@@ -164,7 +182,14 @@ func TestMigratorMigrationStatus(t *testing.T) {
 	setup := func(t *testing.T) (*migrator, *migrationIntentFixture) {
 		t.Helper()
 		fx := newMigrationIntentFixture(t)
-		return &migrator{nsm: fx.nsm, intent: fx.log}, fx
+		return &migrator{
+			nsm: fx.nsm, intent: fx.log, ssm: NewSSM(&fakeSSM{}), ready: true,
+		}, fx
+	}
+	request := func(t *testing.T, m *migrator, fx *migrationIntentFixture) error {
+		t.Helper()
+		_, err := requestMigrationTo(t, ctx, m, fx.signer, targetPCR0)
+		return err
 	}
 
 	t.Run("none", func(t *testing.T) {
@@ -176,9 +201,8 @@ func TestMigratorMigrationStatus(t *testing.T) {
 	})
 
 	t.Run("pending", func(t *testing.T) {
-		m, _ := setup(t)
-		_, err := m.HandleMigrationRequest(ctx, migrationIntentRequested, targetPCR0)
-		require.NoError(t, err)
+		m, fx := setup(t)
+		require.NoError(t, request(t, m, fx))
 		status, err := m.MigrationStatus(ctx)
 
 		require.NoError(t, err)
@@ -188,10 +212,9 @@ func TestMigratorMigrationStatus(t *testing.T) {
 	})
 
 	t.Run("aborted", func(t *testing.T) {
-		m, _ := setup(t)
-		_, err := m.HandleMigrationRequest(ctx, migrationIntentRequested, targetPCR0)
-		require.NoError(t, err)
-		_, err = m.HandleMigrationRequest(ctx, migrationIntentAborted, "")
+		m, fx := setup(t)
+		require.NoError(t, request(t, m, fx))
+		_, err := m.handleMigrationRequest(ctx, migrationIntentAborted, "")
 		require.NoError(t, err)
 		status, err := m.MigrationStatus(ctx)
 
@@ -204,7 +227,7 @@ func TestMigratorMigrationStatus(t *testing.T) {
 		t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "invalid")
 		m, fx := setup(t)
 
-		_, err := m.HandleMigrationRequest(ctx, migrationIntentRequested, targetPCR0)
+		err := request(t, m, fx)
 
 		require.ErrorContains(t, err, "ENCLAVE_MIGRATION_COOLDOWN")
 		require.Empty(t, fx.s3.objects)
@@ -236,32 +259,6 @@ func TestMigrationStatusAt(t *testing.T) {
 	require.Equal(t, migrationStateEligible, status.State)
 	require.Zero(t, status.RemainingSeconds)
 	require.Equal(t, head.PublishedAt, *status.EligibleAt)
-}
-
-func TestMigrationRequestValidate(t *testing.T) {
-	validPCR0 := strings.Repeat("a", 96)
-
-	for _, tc := range []struct {
-		name    string
-		request MigrationRequest
-		wantErr bool
-	}{
-		{name: "missing action", request: MigrationRequest{}, wantErr: true},
-		{name: "unknown action", request: MigrationRequest{Action: "replace"}, wantErr: true},
-		{name: "requested without target", request: MigrationRequest{Action: migrationIntentRequested}, wantErr: true},
-		{name: "requested with invalid target", request: MigrationRequest{Action: migrationIntentRequested, TargetPCR0: "abc"}, wantErr: true},
-		{name: "requested", request: MigrationRequest{Action: migrationIntentRequested, TargetPCR0: validPCR0}},
-		{name: "aborted", request: MigrationRequest{Action: migrationIntentAborted}},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.request.Validate()
-			if tc.wantErr {
-				require.Error(t, err)
-				return
-			}
-			require.NoError(t, err)
-		})
-	}
 }
 
 func TestCompleteMigration(t *testing.T) {
@@ -317,24 +314,19 @@ func TestCompleteMigration(t *testing.T) {
 		for _, opt := range opts {
 			opt(fx)
 		}
-		m, err := NewMigrator(
-			nsm,
+		m, err := newMigrator(nsm, fx.ssm, s3f, migrationIntentBucketName)
+		require.NoError(t, err)
+		m.Promote(
 			&kmsW{nsm: nsm, kms: kmsf, sts: sts, keyID: "old-key"},
-			fx.ssm,
-			s3f,
 			&dek{key: dekKey},
 			[]StaticSecret{secret},
-			migrationIntentBucketName,
 		)
-		require.NoError(t, err)
-		fx.m = m.(*migrator)
+		fx.m = m
 		return fx
 	}
 	request := func(t *testing.T, fx *startMigrationFixture, targetPCR0 string) {
 		t.Helper()
-		status, err := fx.m.HandleMigrationRequest(
-			ctx, migrationIntentRequested, targetPCR0,
-		)
+		status, err := requestMigrationTo(t, ctx, fx.m, fx.session.attestationSign, targetPCR0)
 		require.NoError(t, err)
 		require.Equal(t, migrationStateEligible, status.State)
 	}
@@ -343,6 +335,9 @@ func TestCompleteMigration(t *testing.T) {
 		fx := setup(t)
 		fx.ssmf.params[migrationIntentBucketParam()] = "repointed-after-startup"
 		request(t, fx, newPCR0)
+		// Scope the read assertion below to finalise alone; initiation has its
+		// own SSM traffic.
+		fx.ssmf.calls = nil
 
 		got, err := fx.m.CompleteMigration(ctx)
 
@@ -421,6 +416,23 @@ func TestCompleteMigration(t *testing.T) {
 		fx.kmsf.mu.Unlock()
 	})
 
+	t.Run("losing a cross-process commit race cannot replace the winner", func(t *testing.T) {
+		fx := setup(t)
+		request(t, fx, newPCR0)
+		winner := "key-committed-by-another-predecessor"
+		fx.m.ssm = &losingCommitSSM{
+			SSM:    fx.ssm,
+			key:    kmsKeyIDParam(newPCR0),
+			winner: winner,
+		}
+
+		_, err := fx.m.CompleteMigration(ctx)
+
+		require.ErrorIs(t, err, errMigrationAlreadyFinalised)
+		require.Equal(t, winner, fx.ssmf.params[kmsKeyIDParam(newPCR0)])
+		require.NotEqual(t, migrationKeyID, fx.ssmf.params[kmsKeyIDParam(newPCR0)])
+	})
+
 	t.Run("predecessor cannot read back what it wrote under the migration key",
 		func(t *testing.T) {
 			fx := setup(t)
@@ -452,7 +464,7 @@ func TestCompleteMigration(t *testing.T) {
 	t.Run("rejects active cooldown", func(t *testing.T) {
 		t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "2m")
 		fx := setup(t)
-		status, err := fx.m.HandleMigrationRequest(ctx, migrationIntentRequested, newPCR0)
+		status, err := requestMigrationTo(t, ctx, fx.m, fx.session.attestationSign, newPCR0)
 		require.NoError(t, err)
 		require.Equal(t, migrationStateCoolingDown, status.State)
 
@@ -465,7 +477,7 @@ func TestCompleteMigration(t *testing.T) {
 	t.Run("rejects aborted intent", func(t *testing.T) {
 		fx := setup(t)
 		request(t, fx, newPCR0)
-		_, err := fx.m.HandleMigrationRequest(ctx, migrationIntentAborted, "")
+		_, err := fx.m.handleMigrationRequest(ctx, migrationIntentAborted, "")
 		require.NoError(t, err)
 
 		_, err = fx.m.CompleteMigration(ctx)
@@ -487,16 +499,9 @@ func TestCompleteMigration(t *testing.T) {
 	t.Run("recovers intent after migrator restart", func(t *testing.T) {
 		fx := setup(t)
 		request(t, fx, newPCR0)
-		restarted, err := NewMigrator(
-			fx.m.nsm,
-			fx.m.kms,
-			fx.ssm,
-			fx.s3f,
-			fx.m.dek,
-			fx.m.staticSecrets,
-			migrationIntentBucketName,
-		)
+		restarted, err := newMigrator(fx.m.nsm, fx.ssm, fx.s3f, migrationIntentBucketName)
 		require.NoError(t, err)
+		restarted.Promote(fx.m.kms, fx.m.dek, fx.m.staticSecrets)
 
 		_, err = restarted.CompleteMigration(ctx)
 
@@ -523,7 +528,7 @@ func TestCompleteMigration(t *testing.T) {
 
 		requestDone := make(chan error, 1)
 		go func() {
-			_, err := fx.m.HandleMigrationRequest(ctx, migrationIntentAborted, "")
+			_, err := fx.m.handleMigrationRequest(ctx, migrationIntentAborted, "")
 			requestDone <- err
 		}()
 
@@ -616,6 +621,418 @@ func TestCompleteMigration(t *testing.T) {
 	})
 }
 
+func TestVerifySuccessorAttestation(t *testing.T) {
+	challenge := bytes.Repeat([]byte{0x11}, 32)
+
+	t.Run("derives the target PCR0 from the document", func(t *testing.T) {
+		fx := newSuccessorTestFixture(t)
+
+		doc, err := fx.successor.buildSuccessorAttestation(challenge)
+		require.NoError(t, err)
+
+		got, err := fx.predecessor.verifySuccessorAttestation(doc, challenge)
+
+		require.NoError(t, err)
+		require.Equal(t, fx.targetPCR0, got)
+	})
+
+	t.Run("rejects a document answering a different challenge", func(t *testing.T) {
+		fx := newSuccessorTestFixture(t)
+
+		// The essential replay case: a document that was valid for an earlier
+		// exchange must not authorise a later one.
+		doc, err := fx.successor.buildSuccessorAttestation(bytes.Repeat([]byte{0x22}, 32))
+		require.NoError(t, err)
+
+		_, err = fx.predecessor.verifySuccessorAttestation(doc, challenge)
+
+		require.ErrorContains(t, err, "does not answer the issued challenge")
+	})
+
+	t.Run("rejects a claim for another deployment", func(t *testing.T) {
+		fx := newSuccessorTestFixture(t)
+
+		t.Setenv("ENCLAVE_DEPLOYMENT", "other-deployment")
+		doc, err := fx.successor.buildSuccessorAttestation(challenge)
+		require.NoError(t, err)
+
+		t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+		_, err = fx.predecessor.verifySuccessorAttestation(doc, challenge)
+
+		require.ErrorContains(t, err, "user data")
+	})
+
+	t.Run("rejects a claim with the wrong schema", func(t *testing.T) {
+		fx := newSuccessorTestFixture(t)
+
+		enc, err := cbor.CoreDetEncOptions().EncMode()
+		require.NoError(t, err)
+		payload, err := enc.Marshal(successorClaimV1{
+			Schema:     "enclave.successor_claim.v2",
+			Deployment: "prod",
+		})
+		require.NoError(t, err)
+		raw, _, err := fx.successor.nsm.BuildAttestationDocument(
+			WithNonce(challenge), WithUserData(payload),
+		)
+		require.NoError(t, err)
+
+		_, err = fx.predecessor.verifySuccessorAttestation(
+			base64.StdEncoding.EncodeToString(raw), challenge,
+		)
+
+		require.ErrorContains(t, err, "user data")
+	})
+
+	t.Run("rejects a document signed by an unrelated root", func(t *testing.T) {
+		fx := newSuccessorTestFixture(t)
+
+		now := time.Now()
+		stranger := successorMigrator(t, newTestAttestationSigner(
+			t, now.Add(-time.Hour), now.Add(time.Hour),
+		), bytes.Repeat([]byte{0xcd}, 48))
+		doc, err := stranger.buildSuccessorAttestation(challenge)
+		require.NoError(t, err)
+
+		_, err = fx.predecessor.verifySuccessorAttestation(doc, challenge)
+
+		require.Error(t, err)
+	})
+
+	t.Run("rejects a malformed document", func(t *testing.T) {
+		fx := newSuccessorTestFixture(t)
+
+		_, err := fx.predecessor.verifySuccessorAttestation("not base64", challenge)
+
+		require.Error(t, err)
+	})
+
+	t.Run("requires both a document and a challenge", func(t *testing.T) {
+		fx := newSuccessorTestFixture(t)
+
+		_, err := fx.predecessor.verifySuccessorAttestation("", challenge)
+		require.ErrorContains(t, err, "successor attestation is required")
+
+		doc, err := fx.successor.buildSuccessorAttestation(challenge)
+		require.NoError(t, err)
+		_, err = fx.predecessor.verifySuccessorAttestation(doc, nil)
+		require.ErrorContains(t, err, "challenge is required")
+
+		_, err = fx.successor.buildSuccessorAttestation(nil)
+		require.ErrorContains(t, err, "challenge is required")
+	})
+}
+
+func TestChallengeRotationRetiresOldAnswers(t *testing.T) {
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+	t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "0s")
+
+	ctx := context.Background()
+	fx := newMigrationIntentFixture(t)
+	ssmf := &fakeSSM{}
+	m := &migrator{nsm: fx.nsm, intent: fx.log, ssm: NewSSM(ssmf), ready: true}
+	target := strings.Repeat("cd", 48)
+
+	own, err := m.ownPCR0()
+	require.NoError(t, err)
+	require.NoError(t, m.publishChallenge(ctx, own))
+	stale, err := m.ssm.MayGet(ctx, migrationChallengeParam(own))
+	require.NoError(t, err)
+
+	candidate := successorMigrator(t, fx.signer, mustDecodeHex(t, target))
+	doc, err := candidate.buildSuccessorAttestation(mustDecodeHex(t, stale))
+	require.NoError(t, err)
+
+	// Force rotation, as the control loop does once the challenge ages out.
+	m.mu.Lock()
+	m.challengeAt = time.Now().Add(-2 * migrationChallengeRotate)
+	m.mu.Unlock()
+	require.NoError(t, m.publishChallenge(ctx, own))
+
+	// The answer to the retired challenge is now inert, so no intent is recorded.
+	require.NoError(t, m.ssm.Set(
+		ctx, successorAttestationParam(own, target), doc, WithAdvancedTier(),
+	))
+	require.NoError(t, m.adoptCandidate(ctx, own))
+
+	status, err := m.MigrationStatus(ctx)
+	require.NoError(t, err)
+	require.Equal(t, migrationStateNone, status.State)
+	require.Empty(t, fx.s3.objects, "a stale answer must publish no intent")
+}
+
+func TestAdoptCandidateRefusesWhileAmbiguous(t *testing.T) {
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+	t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "0s")
+
+	ctx := context.Background()
+	fx := newMigrationIntentFixture(t)
+	m := &migrator{nsm: fx.nsm, intent: fx.log, ssm: NewSSM(&fakeSSM{}), ready: true}
+
+	own, err := m.ownPCR0()
+	require.NoError(t, err)
+	require.NoError(t, m.publishChallenge(ctx, own))
+	challenge, err := m.ssm.MayGet(ctx, migrationChallengeParam(own))
+	require.NoError(t, err)
+
+	// Two live candidates answer the same challenge. Nobody intended that, so
+	// the predecessor keeps serving rather than picking one.
+	for _, target := range []string{strings.Repeat("cd", 48), strings.Repeat("ee", 48)} {
+		candidate := successorMigrator(t, fx.signer, mustDecodeHex(t, target))
+		doc, err := candidate.buildSuccessorAttestation(mustDecodeHex(t, challenge))
+		require.NoError(t, err)
+		require.NoError(t, m.ssm.Set(
+			ctx, successorAttestationParam(own, target), doc, WithAdvancedTier(),
+		))
+	}
+
+	err = m.adoptCandidate(ctx, own)
+
+	require.ErrorIs(t, err, errMigrationSuccessorAmbiguous)
+	require.Empty(t, fx.s3.objects, "an ambiguous round must publish no intent")
+}
+
+func TestHandleMigrationRequestDerivesTargetFromAttestation(t *testing.T) {
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+	t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "0s")
+
+	ctx := context.Background()
+	fx := newMigrationIntentFixture(t)
+	m := &migrator{nsm: fx.nsm, intent: fx.log, ssm: NewSSM(&fakeSSM{}), ready: true}
+	attested := strings.Repeat("cd", 48)
+
+	status, err := requestMigrationTo(t, ctx, m, fx.signer, attested)
+
+	require.NoError(t, err)
+	// The recorded target is the successor's own measurement. Nothing the caller
+	// sent could have named it.
+	require.Equal(t, attested, status.TargetPCR0)
+}
+
+func TestCandidateRefusesStateOperations(t *testing.T) {
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+	t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "0s")
+
+	ctx := context.Background()
+	fx := newMigrationIntentFixture(t)
+	m := &migrator{nsm: fx.nsm, intent: fx.log, ssm: NewSSM(&fakeSSM{})}
+
+	require.False(t, m.Ready())
+
+	_, err := m.handleMigrationRequest(ctx, migrationIntentRequested, strings.Repeat("cd", 48))
+	require.ErrorIs(t, err, errMigrationCandidate)
+	require.Empty(t, fx.s3.objects, "a candidate must publish no intent")
+
+	// A candidate can still prove who it is: that is the whole point of the mode.
+	doc, err := m.buildSuccessorAttestation(bytes.Repeat([]byte{0x11}, 32))
+	require.NoError(t, err)
+	require.NotEmpty(t, doc)
+}
+
+func TestInboundIntentIsReportedButNeverTrusted(t *testing.T) {
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+	t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "0s")
+
+	ctx := context.Background()
+	fx := newMigrationIntentFixture(t)
+	m := &migrator{nsm: fx.nsm, intent: fx.log, ssm: NewSSM(&fakeSSM{}), ready: true}
+	target := strings.Repeat("cd", 48)
+
+	_, err := requestMigrationTo(t, ctx, m, fx.signer, target)
+	require.NoError(t, err)
+
+	t.Run("a candidate can see who is offering it a handoff", func(t *testing.T) {
+		inbound, err := fx.log.InboundIntent(ctx, target)
+
+		require.NoError(t, err)
+		require.NotNil(t, inbound)
+		require.Equal(t, fx.source, inbound.SourcePCR0)
+		require.Equal(t, target, inbound.TargetPCR0)
+	})
+
+	t.Run("intents aimed elsewhere are not reported", func(t *testing.T) {
+		inbound, err := fx.log.InboundIntent(ctx, strings.Repeat("ee", 48))
+
+		require.NoError(t, err)
+		require.Nil(t, inbound)
+	})
+
+	t.Run("an inbound intent does not make an enclave adoptable", func(t *testing.T) {
+		// The intent log is host-writable, so a record naming us proves nothing.
+		// Only the commit pointer may end candidacy.
+		setStateOriginTestEnv(t)
+		t.Setenv("ENCLAVE_PREVIOUS_PCR0", strings.Repeat("99", 48))
+
+		_, ssm := stateOriginTestSSM(nil)
+		_, err := loadUnverifiedState(ctx, ssm, mustDecodeHex(t, target))
+
+		require.ErrorIs(t, err, errAwaitingHandoff)
+	})
+}
+
+func TestEstablishStateAwaitingHandoffDoesNotRetryFatalErrors(t *testing.T) {
+	setStateOriginTestEnv(t)
+
+	// A deployment whose intent bucket is unreadable is broken, not pending: the
+	// boot must die rather than spin forever looking like a candidate.
+	_, ssm := stateOriginTestSSM(map[string]string{migrationIntentBucketParam(): "UNSET"})
+	pcr0 := bytes.Repeat([]byte{0xab}, 48)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	_, err := establishStateAwaitingHandoff(
+		ctx,
+		&nsmW{nsm: &fakeNSM{session: newStatefulNSMSession(t, map[uint][]byte{0: pcr0})}},
+		newFakeKMS(),
+		&fakeSTS{arn: testRoleARN},
+		ssm,
+	)
+
+	require.ErrorContains(t, err, "migration intent bucket")
+	require.NotErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestMigrationControlCommitsAndAborts(t *testing.T) {
+	const bucketName = "migration-intent-bucket"
+
+	oldPCR0 := bytes.Repeat([]byte{0xab}, 48)
+	oldPCR0Hex := hex.EncodeToString(oldPCR0)
+	newPCR0 := strings.Repeat("cd", 48)
+
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+	t.Setenv("ENCLAVE_KMS_KEY_LOCKED", "true")
+	t.Setenv("ENCLAVE_MIGRATION_COOLDOWN", "0s")
+	t.Setenv("ENCLAVE_MIGRATION_INTENT_RETENTION", "87600h")
+	t.Setenv("ENCLAVE_SECRETS_CONFIG", `[]`)
+
+	ctx := context.Background()
+	setup := func(t *testing.T) (*migrator, *fakeSSM, *fakeNSMSession) {
+		t.Helper()
+		session := newStatefulNSMSession(t, map[uint][]byte{
+			0:                 oldPCR0,
+			migrationPCRIndex: make([]byte, 48),
+		})
+		nsm := &nsmW{nsm: &fakeNSM{
+			session:     session,
+			verifyRoots: session.attestationSign.roots,
+		}}
+		ssmf := &fakeSSM{params: map[string]string{
+			migrationIntentBucketParam(): bucketName,
+			kmsKeyIDParam(oldPCR0Hex):    "old-key",
+		}}
+		kmsf := newFakeKMS()
+		m, err := newMigrator(nsm, NewSSM(ssmf), newFakeS3(), bucketName)
+		require.NoError(t, err)
+		m.Promote(
+			&kmsW{nsm: nsm, kms: kmsf, sts: &fakeSTS{arn: testRoleARN}, keyID: "old-key"},
+			&dek{key: bytes.Repeat([]byte{0x42}, 32)},
+			nil,
+		)
+		return m, ssmf, session
+	}
+
+	// Standing in for a candidate publishing its answer to the live challenge.
+	answer := func(t *testing.T, m *migrator, session *fakeNSMSession, target string) {
+		t.Helper()
+		challenge, err := m.ssm.MayGet(ctx, migrationChallengeParam(oldPCR0Hex))
+		require.NoError(t, err)
+		require.NotEmpty(t, challenge, "predecessor must publish a challenge")
+
+		candidate := successorMigrator(t, session.attestationSign, mustDecodeHex(t, target))
+		doc, err := candidate.buildSuccessorAttestation(mustDecodeHex(t, challenge))
+		require.NoError(t, err)
+		require.NoError(t, m.ssm.Set(
+			ctx, successorAttestationParam(oldPCR0Hex, target), doc, WithAdvancedTier(),
+		))
+	}
+
+	t.Run("a candidate answering is the whole trigger", func(t *testing.T) {
+		m, ssmf, session := setup(t)
+
+		// Round one publishes a challenge; nobody has answered yet.
+		require.NoError(t, m.advanceMigration(ctx))
+		require.Empty(t, ssmf.params[kmsKeyIDParam(newPCR0)])
+
+		answer(t, m, session, newPCR0)
+
+		// Round two adopts the answer, round three commits once eligible.
+		require.NoError(t, m.advanceMigration(ctx))
+		require.NoError(t, m.advanceMigration(ctx))
+
+		require.NotEmpty(t, ssmf.params[kmsKeyIDParam(newPCR0)],
+			"the successor's commit pointer must appear")
+		require.Equal(t, "old-key", ssmf.params[kmsKeyIDParam(oldPCR0Hex)],
+			"the predecessor's own pointer must survive")
+	})
+
+	t.Run("an operator abort stops the commit", func(t *testing.T) {
+		m, ssmf, session := setup(t)
+
+		require.NoError(t, m.advanceMigration(ctx))
+		answer(t, m, session, newPCR0)
+		require.NoError(t, m.advanceMigration(ctx))
+
+		// Written before the cooldown elapses; this is the only operator control.
+		ssmf.params[migrationAbortParam(oldPCR0Hex)] = newPCR0
+
+		require.NoError(t, m.advanceMigration(ctx))
+
+		require.Empty(t, ssmf.params[kmsKeyIDParam(newPCR0)],
+			"an aborted handoff must not commit")
+		status, err := m.MigrationStatus(ctx)
+		require.NoError(t, err)
+		require.Equal(t, migrationStateAborted, status.State)
+	})
+
+	t.Run("an abort naming a different target does not apply", func(t *testing.T) {
+		m, ssmf, session := setup(t)
+
+		require.NoError(t, m.advanceMigration(ctx))
+		answer(t, m, session, newPCR0)
+		require.NoError(t, m.advanceMigration(ctx))
+
+		ssmf.params[migrationAbortParam(oldPCR0Hex)] = strings.Repeat("ee", 48)
+
+		require.NoError(t, m.advanceMigration(ctx))
+
+		require.NotEmpty(t, ssmf.params[kmsKeyIDParam(newPCR0)])
+	})
+}
+
+func TestCandidateAnswersPublishedChallenges(t *testing.T) {
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+	t.Setenv("ENCLAVE_MIGRATION_INTENT_RETENTION", "87600h")
+
+	ctx := context.Background()
+	fx := newMigrationIntentFixture(t)
+	ssmf := &fakeSSM{params: map[string]string{}}
+	m := &migrator{nsm: fx.nsm, intent: fx.log, ssm: NewSSM(ssmf)}
+
+	predecessor := strings.Repeat("11", 48)
+	ssmf.params[migrationChallengeParam(predecessor)] = strings.Repeat("ab", 32)
+
+	require.NoError(t, m.answerChallenges(ctx))
+
+	// The candidate publishes under the challenging enclave's prefix, so a
+	// predecessor finds only answers to its own challenge.
+	doc := ssmf.params[successorAttestationParam(predecessor, fx.source)]
+	require.NotEmpty(t, doc)
+
+	target, err := m.verifySuccessorAttestation(
+		doc, mustDecodeHex(t, strings.Repeat("ab", 32)),
+	)
+	require.NoError(t, err)
+	require.Equal(t, fx.source, target)
+}
+
 func predecessorNSM(t *testing.T, currentPCR0 []byte, verifyResult *nitrite.Result) NSM {
 	t.Helper()
 	session := &fakeNSMSession{responses: []response.Response{
@@ -634,6 +1051,28 @@ type startMigrationFixture struct {
 	ssm     SSM
 	s3f     *fakeS3
 	kmsf    *fakeKMS
+}
+
+// losingCommitSSM simulates another predecessor winning after this process's
+// initial MayGet but before its final create-only write.
+type losingCommitSSM struct {
+	SSM
+	key    string
+	winner string
+}
+
+func (s *losingCommitSSM) SetIfAbsent(
+	ctx context.Context,
+	key, val string,
+	opts ...SSMSetOption,
+) (bool, error) {
+	if key != s.key {
+		return s.SSM.SetIfAbsent(ctx, key, val, opts...)
+	}
+	if err := s.SSM.Set(ctx, key, s.winner); err != nil {
+		return false, err
+	}
+	return false, nil
 }
 
 type blockingPrimaryKMS struct {
@@ -674,6 +1113,61 @@ func requireNoMigrationSideEffects(
 	}
 }
 
+// successorMigrator stands in for a live candidate. It signs with the
+// predecessor's test root, mirroring production where every enclave chains to
+// the same AWS Nitro root — otherwise the predecessor could not verify any
+// document but its own, and the exchange would be untestable for the wrong
+// reason. Only m.nsm is populated, which is all the claim methods reach for.
+func successorMigrator(t *testing.T, signer *testAttestationSigner, pcr0 []byte) *migrator {
+	t.Helper()
+	return &migrator{nsm: &nsmW{nsm: &fakeNSM{session: &fakeNSMSession{
+		t:                t,
+		pcrs:             map[uint][]byte{0: append([]byte(nil), pcr0...)},
+		locks:            map[uint]bool{},
+		attestationSign:  signer,
+		attestationRoots: x509.NewCertPool(),
+	}}}}
+}
+
+// requestMigrationTo drives the real initiation exchange through SSM: the
+// predecessor publishes a challenge, a candidate answers it, and the predecessor
+// adopts that answer. Nothing here names the target to the predecessor.
+func requestMigrationTo(
+	t *testing.T,
+	ctx context.Context,
+	m *migrator,
+	predecessorSigner *testAttestationSigner,
+	targetPCR0 string,
+) (*MigrationStatus, error) {
+	t.Helper()
+
+	own, err := m.ownPCR0()
+	require.NoError(t, err)
+	require.NoError(t, m.publishChallenge(ctx, own))
+
+	challenge, err := m.ssm.MayGet(ctx, migrationChallengeParam(own))
+	require.NoError(t, err)
+
+	candidate := successorMigrator(t, predecessorSigner, mustDecodeHex(t, targetPCR0))
+	doc, err := candidate.buildSuccessorAttestation(mustDecodeHex(t, challenge))
+	require.NoError(t, err)
+	require.NoError(t, m.ssm.Set(
+		ctx, successorAttestationParam(own, targetPCR0), doc, WithAdvancedTier(),
+	))
+
+	if err := m.adoptCandidate(ctx, own); err != nil {
+		return nil, err
+	}
+	return m.MigrationStatus(ctx)
+}
+
+func mustDecodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+	decoded, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return decoded
+}
+
 func requireKMSCiphertextPlaintext(
 	t *testing.T,
 	kmsf *fakeKMS,
@@ -704,4 +1198,33 @@ func requireExtendPCR(
 	}
 	t.Fatalf("ExtendPCR(%d) was not requested", index)
 	return nil
+}
+
+// successorTestFixture pairs a predecessor with a would-be successor signing
+// under the same root, as real enclaves share the AWS Nitro root.
+type successorTestFixture struct {
+	predecessor *migrator
+	signer      *testAttestationSigner
+	successor   *migrator
+	targetPCR0  string
+}
+
+func newSuccessorTestFixture(t *testing.T) *successorTestFixture {
+	t.Helper()
+	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
+	t.Setenv("ENCLAVE_APP_NAME", "myapp")
+
+	session := newStatefulNSMSession(t, map[uint][]byte{0: bytes.Repeat([]byte{0xab}, 48)})
+	predecessor := &migrator{nsm: &nsmW{nsm: &fakeNSM{
+		session:     session,
+		verifyRoots: session.attestationSign.roots,
+	}}}
+	target := bytes.Repeat([]byte{0xcd}, 48)
+
+	return &successorTestFixture{
+		predecessor: predecessor,
+		signer:      session.attestationSign,
+		successor:   successorMigrator(t, session.attestationSign, target),
+		targetPCR0:  hex.EncodeToString(target),
+	}
 }

--- a/runtime/migration_intent.go
+++ b/runtime/migration_intent.go
@@ -41,6 +41,12 @@ var (
 		"migration intent: target PCR0 is this enclave",
 	)
 	errMigrationAlreadyFinalised = errors.New("migration: already finalised for this target")
+	errMigrationCandidate        = errors.New(
+		"migration: this enclave is a candidate and holds no state to hand off",
+	)
+	errMigrationSuccessorAmbiguous = errors.New(
+		"migration: more than one candidate answered the challenge",
+	)
 )
 
 type migrationIntentV1 struct {
@@ -160,6 +166,64 @@ func (l *migrationIntentLog) Abort(ctx context.Context) (*migrationIntent, error
 		return nil, errMigrationIntentAborted
 	}
 	return l.append(ctx, sourcePCR0, head.Sequence, migrationIntentAborted, head.TargetPCR0)
+}
+
+func (l *migrationIntentLog) InboundIntent(
+	ctx context.Context,
+	targetPCR0 string,
+) (*migrationIntent, error) {
+	sources := map[string]bool{}
+	var keyMarker, versionMarker *string
+	for {
+		out, err := l.s3.ListObjectVersions(ctx, &s3.ListObjectVersionsInput{
+			Bucket:          aws.String(l.bucket),
+			Prefix:          aws.String(migrationIntentPrefix),
+			KeyMarker:       keyMarker,
+			VersionIdMarker: versionMarker,
+		})
+		if err != nil {
+			return nil, fmt.Errorf(
+				"%w: list migration intent sources: %w",
+				errMigrationIntentStoreUnavailable,
+				err,
+			)
+		}
+		for _, version := range out.Versions {
+			source, _, ok := parseMigrationIntentObjectKey(aws.ToString(version.Key))
+			if ok && !strings.EqualFold(source, targetPCR0) {
+				sources[source] = true
+			}
+		}
+		if !aws.ToBool(out.IsTruncated) {
+			break
+		}
+		if out.NextKeyMarker == nil && out.NextVersionIdMarker == nil {
+			return nil, fmt.Errorf(
+				"%w: list migration intent sources: truncated response missing markers",
+				errMigrationIntentStoreUnavailable,
+			)
+		}
+		keyMarker, versionMarker = out.NextKeyMarker, out.NextVersionIdMarker
+	}
+
+	var newest *migrationIntent
+	for source := range sources {
+		head, tie, err := l.deriveHead(ctx, source)
+		if err != nil {
+			return nil, err
+		}
+		if head == nil || tie || head.Action != migrationIntentRequested {
+			continue
+		}
+		if !strings.EqualFold(head.TargetPCR0, targetPCR0) {
+			continue
+		}
+		if newest == nil || head.PublishedAt.After(newest.PublishedAt) {
+			newest = head
+		}
+	}
+
+	return newest, nil
 }
 
 func (l *migrationIntentLog) append(

--- a/runtime/nsm.go
+++ b/runtime/nsm.go
@@ -52,6 +52,11 @@ type NSM interface {
 		expectedPCRs map[uint]string,
 		expectedUserData []byte,
 	) error
+	VerifyAttestationDocument(
+		attestDocB64 string,
+		expectedPCRs map[uint]string,
+		expectedUserData []byte,
+	) (*nitrite.Result, error)
 	BuildAttestationDocument(opts ...BuildAttestationOption) ([]byte, *rsa.PrivateKey, error)
 	LockPCR(index uint) error
 	ExtendPCR(index uint, data []byte) error
@@ -98,33 +103,42 @@ func (n *nsmW) VerifyAttestation(
 	expectedPCRs map[uint]string,
 	expectedUserData []byte,
 ) error {
+	_, err := n.VerifyAttestationDocument(attestDocB64, expectedPCRs, expectedUserData)
+	return err
+}
+
+func (n *nsmW) VerifyAttestationDocument(
+	attestDocB64 string,
+	expectedPCRs map[uint]string,
+	expectedUserData []byte,
+) (*nitrite.Result, error) {
 	attestDoc, err := base64.StdEncoding.DecodeString(attestDocB64)
 	if err != nil {
-		return fmt.Errorf("decode attestation base64: %w", err)
+		return nil, fmt.Errorf("decode attestation base64: %w", err)
 	}
 
 	result, err := n.nsm.VerifyAttestationSig(attestDoc)
 	if err != nil {
-		return fmt.Errorf("verify predecessor attestation: %w", err)
+		return nil, fmt.Errorf("verify predecessor attestation: %w", err)
 	}
 
 	for index, expected := range expectedPCRs {
 		attestedPCR, ok := result.Document.PCRs[index]
 		if !ok {
-			return fmt.Errorf("PCR%d not found in attestation document", index)
+			return nil, fmt.Errorf("PCR%d not found in attestation document", index)
 		}
 		attestedPCRHex := hex.EncodeToString(attestedPCR)
 		if !strings.EqualFold(attestedPCRHex, expected) {
-			return fmt.Errorf("attested PCR%d does not match expected: %s != %s",
+			return nil, fmt.Errorf("attested PCR%d does not match expected: %s != %s",
 				index, attestedPCRHex, expected)
 		}
 	}
 
 	if !bytes.Equal(result.Document.UserData, expectedUserData) {
-		return fmt.Errorf("attested user data does not match expected user data")
+		return nil, fmt.Errorf("attested user data does not match expected user data")
 	}
 
-	return nil
+	return result, nil
 }
 
 func (n *nsmW) BuildAttestationDocument(

--- a/runtime/nsm_test.go
+++ b/runtime/nsm_test.go
@@ -530,6 +530,18 @@ func (s *testAttestationSigner) build(
 	publicKey ...[]byte,
 ) signedAttestation {
 	t.Helper()
+	return s.buildWithNonce(t, pcrs, timestamp, userData, nil, publicKey...)
+}
+
+func (s *testAttestationSigner) buildWithNonce(
+	t *testing.T,
+	pcrs map[uint][]byte,
+	timestamp time.Time,
+	userData []byte,
+	nonce []byte,
+	publicKey ...[]byte,
+) signedAttestation {
+	t.Helper()
 
 	document := &nitrite.Document{
 		ModuleID:    "test-module",
@@ -539,6 +551,7 @@ func (s *testAttestationSigner) build(
 		Certificate: s.leafDER,
 		CABundle:    [][]byte{s.caDER},
 		UserData:    userData,
+		Nonce:       nonce,
 	}
 	if len(publicKey) > 0 {
 		document.PublicKey = publicKey[0]
@@ -796,13 +809,9 @@ func buildSignedAttestationForRequest(
 	req *request.Attestation,
 ) signedAttestation {
 	t.Helper()
-	return signer.build(
-		t,
-		pcrs,
-		time.Now(),
-		req.UserData,
-		req.PublicKey,
-	)
+	// The nonce must survive into the document: it is the only freshness signal
+	// a verifier has, so a fake that dropped it would make replay untestable.
+	return signer.buildWithNonce(t, pcrs, time.Now(), req.UserData, req.Nonce, req.PublicKey)
 }
 
 func clonePCRs(pcrs map[uint][]byte) map[uint][]byte {

--- a/runtime/runtime.go
+++ b/runtime/runtime.go
@@ -105,29 +105,17 @@ func Run(ctx context.Context, cfg Config) error {
 	}
 
 	ssm := NewSSM(aws.SSM)
-	verified, err := EstablishState(
-		ctx,
-		nsm,
-		aws.KMS,
-		aws.STS,
-		ssm,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to establish state: %w", err)
-	}
 
-	if err := ExtendPCRRegistersWithStaticSecrets(nsm, verified.secrets); err != nil {
-		return fmt.Errorf("failed to extend PCR registers with static secrets: %w", err)
+	migrationIntentBucket, err := ssm.MustGet(ctx, migrationIntentBucketParam())
+	if err != nil {
+		return fmt.Errorf("failed to get migration intent bucket name: %w", err)
 	}
 
 	migrator, err := NewMigrator(
 		nsm,
-		verified.kms,
 		NewSSMTTLCache(ssm, time.Second*5),
 		aws.S3,
-		verified.dek,
-		verified.secrets,
-		verified.migrationIntentBucketName,
+		migrationIntentBucket,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to initialize migrator: %w", err)
@@ -137,9 +125,28 @@ func Run(ctx context.Context, cfg Config) error {
 		return fmt.Errorf("failed to configure enclave info handler: %w", err)
 	}
 
-	if err := servers.StartMigrationControlServer(ctx, migrator); err != nil {
-		return fmt.Errorf("failed to start migration control server: %w", err)
+	// Answer any predecessor's challenge while we wait. A candidate that never
+	// gets migrated to simply keeps answering; nothing else happens.
+	go migrator.RunCandidateAttestation(ctx)
+
+	candidateCertCb, err := configureSelfSignedCert(&cfg, hashes)
+	if err != nil {
+		return fmt.Errorf("failed to configure candidate TLS: %w", err)
 	}
+	rt.SetTLSCertCallback(withDefaultSNI(cfg.FQDN, candidateCertCb))
+
+	verified, err := establishStateAwaitingHandoff(ctx, nsm, aws.KMS, aws.STS, ssm)
+	if err != nil {
+		return fmt.Errorf("failed to establish state: %w", err)
+	}
+
+	if err := ExtendPCRRegistersWithStaticSecrets(nsm, verified.secrets); err != nil {
+		return fmt.Errorf("failed to extend PCR registers with static secrets: %w", err)
+	}
+
+	migrator.Promote(verified.kms, verified.dek, verified.secrets)
+
+	go migrator.RunMigrationControl(ctx)
 
 	tlsCertCb, err := ConfigureTLS(ctx, &cfg, aws.S3, verified.dek, ssm, hashes)
 	if err != nil {
@@ -281,6 +288,7 @@ type runtimeState struct {
 	isExit          atomic.Bool
 	exitError       atomic.Value
 	tlsReadyOnce    sync.Once
+	tlsMu           sync.RWMutex
 	tlsCertCallback TLSCertCallback
 	tlsReadyCh      chan struct{}
 	listenErrCh     chan error
@@ -309,15 +317,18 @@ func (r *runtimeState) UpstreamAppInfo() UpstreamAppInfo {
 }
 
 func (r *runtimeState) SetTLSCertCallback(cb TLSCertCallback) {
-	r.tlsReadyOnce.Do(func() {
-		r.tlsCertCallback = cb
-		close(r.tlsReadyCh)
-	})
+	r.tlsMu.Lock()
+	r.tlsCertCallback = cb
+	r.tlsMu.Unlock()
+
+	r.tlsReadyOnce.Do(func() { close(r.tlsReadyCh) })
 }
 
 func (r *runtimeState) GetTLSCertCallback(ctx context.Context) (TLSCertCallback, error) {
 	select {
 	case <-r.tlsReadyCh:
+		r.tlsMu.RLock()
+		defer r.tlsMu.RUnlock()
 		return r.tlsCertCallback, nil
 	case <-ctx.Done():
 		return nil, ctx.Err()

--- a/runtime/runtime_test.go
+++ b/runtime/runtime_test.go
@@ -134,12 +134,3 @@ func waitTestResult(t *testing.T, ch <-chan error) error {
 		return nil
 	}
 }
-
-func waitTestSignal(t *testing.T, ch <-chan struct{}) {
-	t.Helper()
-	select {
-	case <-ch:
-	case <-time.After(time.Second):
-		t.Fatal("timed out waiting for signal")
-	}
-}

--- a/runtime/servers.go
+++ b/runtime/servers.go
@@ -21,16 +21,12 @@ import (
 	"time"
 
 	"github.com/ArkLabsHQ/enclave/runtime/nitriding"
-	"github.com/mdlayher/vsock"
 	"golang.org/x/net/http2"
 )
 
 const (
-	indexPage                 = "This host runs inside an AWS Nitro Enclave.\n"
-	nonceNumDigits            = 40 // 20-byte nonce, hex-encoded
-	migrationControlPort      = 8003
-	migrationRequestPath      = "/request-migration"
-	migrationFinalisationPath = "/finalise-migration"
+	indexPage      = "This host runs inside an AWS Nitro Enclave.\n"
+	nonceNumDigits = 40 // 20-byte nonce, hex-encoded
 )
 
 var (
@@ -46,7 +42,6 @@ var (
 type Servers interface {
 	Start(ctx context.Context, cfg Config) error
 	ConfigureEnclaveInfoHandler(ctx context.Context, migrator Migrator, ssm SSM) error
-	StartMigrationControlServer(ctx context.Context, migrator Migrator) error
 }
 
 type servers struct {
@@ -105,7 +100,9 @@ func SetupHttpServers(
 	em.HandleFunc("GET /enclave/config", configHandler(cfg))
 	em.Handle("/v1/", corsWildcard(sm))
 	em.Handle("/health", sm)
-	em.Handle("/", revProxy)
+	// A candidate has no application behind the proxy. Say so, rather than
+	// letting every unmatched path 502 against a process that was never started.
+	em.Handle("/", appProxy(rt, revProxy))
 
 	im := http.NewServeMux()
 	im.Handle("/v1/", sm)
@@ -182,6 +179,8 @@ func (s *servers) Start(ctx context.Context, cfg Config) error {
 // RuntimeInfo is the JSON body returned by GET /v1/enclave-info.
 type RuntimeInfo struct {
 	Version                  string           `json:"version"`
+	Status                   string           `json:"status"`
+	Candidate                *CandidateInfo   `json:"candidate,omitempty"`
 	PreviousPCR0             string           `json:"previous_pcr0"`
 	PreviousPCR0Attestation  string           `json:"previous_pcr0_attestation,omitempty"`
 	AttestationPubkey        string           `json:"attestation_pubkey,omitempty"`
@@ -191,6 +190,11 @@ type RuntimeInfo struct {
 	UpstreamApp              UpstreamAppInfo  `json:"upstream_app"`
 	KMSKeyLocked             bool             `json:"kms_key_locked"`
 }
+
+const (
+	runtimeStatusCandidate = "candidate"
+	runtimeStatusReady     = "ready"
+)
 
 func (s *servers) ConfigureEnclaveInfoHandler(
 	ctx context.Context,
@@ -220,8 +224,22 @@ func (s *servers) ConfigureEnclaveInfoHandler(
 			return
 		}
 
+		status := runtimeStatusReady
+		var candidate *CandidateInfo
+		if !migrator.Ready() {
+			status = runtimeStatusCandidate
+			// Best-effort: a candidate that cannot reach the intent log is
+			// still a candidate, and should say so rather than fail.
+			if candidate, err = migrator.CandidateInfo(r.Context()); err != nil {
+				slog.Warn("could not read inbound migration intent", "error", err)
+				candidate = nil
+			}
+		}
+
 		_ = json.NewEncoder(w).Encode(RuntimeInfo{
 			Version:                  Version,
+			Status:                   status,
+			Candidate:                candidate,
 			PreviousPCR0:             prevInfo.PCR0,
 			PreviousPCR0Attestation:  prevInfo.Attestation,
 			AttestationPubkey:        s.signer.Pubkey(),
@@ -236,97 +254,10 @@ func (s *servers) ConfigureEnclaveInfoHandler(
 	return nil
 }
 
-func (s *servers) StartMigrationControlServer(ctx context.Context, migrator Migrator) error {
-	lis, err := vsock.Listen(migrationControlPort, nil)
-	if err != nil {
-		return fmt.Errorf(
-			"listen on migration control vsock port %d: %w",
-			migrationControlPort,
-			err,
-		)
-	}
-
-	slog.Info("starting migration control listener", "vsock_port", migrationControlPort)
-	s.serveMigrationControl(ctx, migrator, lis)
-	return nil
-}
-
-func (s *servers) serveMigrationControl(
-	ctx context.Context,
-	migrator Migrator,
-	lis net.Listener,
-) {
-	server := &http.Server{Handler: migrationControlHandler(migrator)}
-
-	go func() {
-		<-ctx.Done()
-		_ = server.Close()
-	}()
-
-	go func() {
-		if err := server.Serve(lis); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			s.rt.NotifyListenerError(fmt.Errorf("migration control listener: %w", err))
-		}
-	}()
-}
-
-func migrationControlHandler(migrator Migrator) http.Handler {
-	mux := http.NewServeMux()
-	mux.HandleFunc("POST "+migrationRequestPath, func(w http.ResponseWriter, r *http.Request) {
-		var req MigrationRequest
-		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
-			http.Error(w, fmt.Sprintf("invalid request body: %v", err), http.StatusBadRequest)
-			return
-		}
-
-		if err := req.Validate(); err != nil {
-			http.Error(w, fmt.Sprintf("invalid request: %v", err), http.StatusBadRequest)
-			return
-		}
-
-		status, err := migrator.HandleMigrationRequest(r.Context(), req.Action, req.TargetPCR0)
-		if err != nil {
-			http.Error(
-				w,
-				fmt.Sprintf("failed to handle migration request: %v", err),
-				migrationHTTPStatus(err),
-			)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(status)
-	})
-
-	mux.HandleFunc("POST "+migrationFinalisationPath, func(w http.ResponseWriter, r *http.Request) {
-		res, err := migrator.CompleteMigration(r.Context())
-		if err != nil {
-			http.Error(
-				w,
-				fmt.Sprintf("failed to finalise migration: %v", err),
-				migrationHTTPStatus(err),
-			)
-			return
-		}
-
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(res)
-	})
-
-	return mux
-}
-
+// migrationHTTPStatus maps the errors /v1/enclave-info can surface. Migration
+// itself has no HTTP surface; only reading its status does.
 func migrationHTTPStatus(err error) int {
 	switch {
-	case errors.Is(err, errMigrationCooldownActive):
-		return http.StatusTooEarly
-	case errors.Is(err, errMigrationIntentAbsent),
-		errors.Is(err, errMigrationIntentAborted),
-		errors.Is(err, errMigrationIntentAlreadyRequested),
-		errors.Is(err, errMigrationAlreadyFinalised):
-		return http.StatusConflict
-	case errors.Is(err, errMigrationIntentSelfTarget):
-		return http.StatusBadRequest
 	case errors.Is(err, errMigrationIntentStoreUnavailable):
 		return http.StatusServiceUnavailable
 	default:
@@ -424,6 +355,21 @@ func certCallback(rt RuntimeState) TLSCertCallback {
 		}
 		return getCert(hello)
 	}
+}
+
+// appProxy gates the reverse proxy on the application having been started.
+// Readiness flips only when the child process is forked, so this is exactly
+// "there is something to proxy to".
+func appProxy(rt RuntimeState, revProxy http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !rt.Ready() {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_ = json.NewEncoder(w).Encode(map[string]string{"status": "initializing"})
+			return
+		}
+		revProxy.ServeHTTP(w, r)
+	})
 }
 
 func formatIndexPage(appURL *url.URL) string {

--- a/runtime/servers_test.go
+++ b/runtime/servers_test.go
@@ -7,7 +7,6 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net"
 	"net/http"
@@ -20,39 +19,18 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type migrationControlCall struct {
-	action     string
-	targetPCR0 string
-}
-
 type migrationControlMigrator struct {
-	requestStatus *MigrationStatus
-	requestErr    error
-	requestCalls  []migrationControlCall
-	complete      *CompleteMigrationResult
-	completeErr   error
-	previous      *PreviousPCR0Info
-	previousErr   error
-	status        *MigrationStatus
-	statusErr     error
+	previous     *PreviousPCR0Info
+	previousErr  error
+	status       *MigrationStatus
+	statusErr    error
+	candidate    *CandidateInfo
+	candidateErr error
+	notReady     bool
 }
 
-func (m *migrationControlMigrator) HandleMigrationRequest(
-	_ context.Context,
-	action, targetPCR0 string,
-) (*MigrationStatus, error) {
-	m.requestCalls = append(
-		m.requestCalls,
-		migrationControlCall{action: action, targetPCR0: targetPCR0},
-	)
-	return m.requestStatus, m.requestErr
-}
-
-func (m *migrationControlMigrator) CompleteMigration(
-	_ context.Context,
-) (*CompleteMigrationResult, error) {
-	return m.complete, m.completeErr
-}
+func (m *migrationControlMigrator) RunMigrationControl(context.Context)     {}
+func (m *migrationControlMigrator) RunCandidateAttestation(context.Context) {}
 
 func (m *migrationControlMigrator) PreviousPCR0Info(context.Context) (*PreviousPCR0Info, error) {
 	return m.previous, m.previousErr
@@ -62,40 +40,13 @@ func (m *migrationControlMigrator) MigrationStatus(context.Context) (*MigrationS
 	return m.status, m.statusErr
 }
 
-type blockingListener struct {
-	acceptStarted chan struct{}
-	closed        chan struct{}
+func (m *migrationControlMigrator) CandidateInfo(context.Context) (*CandidateInfo, error) {
+	return m.candidate, m.candidateErr
 }
 
-func newBlockingListener() *blockingListener {
-	return &blockingListener{acceptStarted: make(chan struct{}, 1), closed: make(chan struct{})}
-}
+func (m *migrationControlMigrator) Ready() bool { return !m.notReady }
 
-func (l *blockingListener) Accept() (net.Conn, error) {
-	select {
-	case l.acceptStarted <- struct{}{}:
-	default:
-	}
-	<-l.closed
-	return nil, net.ErrClosed
-}
-
-func (l *blockingListener) Close() error {
-	select {
-	case <-l.closed:
-	default:
-		close(l.closed)
-	}
-	return nil
-}
-
-func (l *blockingListener) Addr() net.Addr { return &net.TCPAddr{} }
-
-type failingListener struct{ err error }
-
-func (l failingListener) Accept() (net.Conn, error) { return nil, l.err }
-func (failingListener) Close() error                { return nil }
-func (failingListener) Addr() net.Addr              { return &net.TCPAddr{} }
+func (m *migrationControlMigrator) Promote(PrimaryKMS, DEK, []StaticSecret) { m.notReady = false }
 
 func TestServersStartReturnsBindErrors(t *testing.T) {
 	occupied, err := net.Listen("tcp", "127.0.0.1:0")
@@ -381,149 +332,6 @@ func TestAttestationHandler(t *testing.T) {
 	})
 }
 
-func TestMigrationControlHandler(t *testing.T) {
-	targetPCR0 := strings.Repeat("ab", 48)
-
-	t.Run("request", func(t *testing.T) {
-		status := &MigrationStatus{State: migrationStateCoolingDown, TargetPCR0: targetPCR0}
-		migrator := &migrationControlMigrator{requestStatus: status}
-		body, err := json.Marshal(MigrationRequest{
-			Action: migrationIntentRequested, TargetPCR0: targetPCR0,
-		})
-		require.NoError(t, err)
-
-		rr := httptest.NewRecorder()
-		migrationControlHandler(migrator).ServeHTTP(rr, httptest.NewRequest(
-			http.MethodPost, migrationRequestPath, bytes.NewReader(body),
-		))
-
-		require.Equal(t, http.StatusOK, rr.Code)
-		require.JSONEq(
-			t,
-			`{"state":"cooling_down","target_pcr0":"`+targetPCR0+`","remaining_seconds":0}`,
-			rr.Body.String(),
-		)
-		require.Equal(t, []migrationControlCall{{
-			action: migrationIntentRequested, targetPCR0: targetPCR0,
-		}}, migrator.requestCalls)
-	})
-
-	t.Run("finalise", func(t *testing.T) {
-		result := &CompleteMigrationResult{
-			PCR0: strings.Repeat("cd", 48), Exported: []string{"secret"},
-		}
-		migrator := &migrationControlMigrator{complete: result}
-
-		rr := httptest.NewRecorder()
-		migrationControlHandler(migrator).ServeHTTP(rr, httptest.NewRequest(
-			http.MethodPost, migrationFinalisationPath, nil,
-		))
-
-		require.Equal(t, http.StatusOK, rr.Code)
-		want, err := json.Marshal(result)
-		require.NoError(t, err)
-		require.JSONEq(t, string(want), rr.Body.String())
-	})
-}
-
-func TestMigrationControlHandlerMapsErrors(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		err  error
-		code int
-	}{
-		{name: "cooldown active", err: errMigrationCooldownActive, code: http.StatusTooEarly},
-		{name: "intent absent", err: errMigrationIntentAbsent, code: http.StatusConflict},
-		{name: "intent aborted", err: errMigrationIntentAborted, code: http.StatusConflict},
-		{name: "intent already requested", err: errMigrationIntentAlreadyRequested, code: http.StatusConflict},
-		{name: "store unavailable", err: errMigrationIntentStoreUnavailable, code: http.StatusServiceUnavailable},
-		{name: "unexpected", err: errors.New("unexpected"), code: http.StatusInternalServerError},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			migrator := &migrationControlMigrator{
-				completeErr: fmt.Errorf("wrapped migration error: %w", tc.err),
-			}
-			rr := httptest.NewRecorder()
-			migrationControlHandler(migrator).ServeHTTP(rr, httptest.NewRequest(
-				http.MethodPost, migrationFinalisationPath, nil,
-			))
-
-			require.Equal(t, tc.code, rr.Code)
-			require.Contains(t, rr.Body.String(), tc.err.Error())
-		})
-	}
-}
-
-func TestMigrationControlHandlerRejectsInvalidRequests(t *testing.T) {
-	for _, tc := range []struct {
-		name string
-		path string
-		body string
-	}{
-		{name: "malformed request", path: migrationRequestPath, body: "{"},
-		{name: "missing request target", path: migrationRequestPath, body: `{"action":"requested"}`},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			migrator := &migrationControlMigrator{}
-			rr := httptest.NewRecorder()
-			migrationControlHandler(migrator).ServeHTTP(rr, httptest.NewRequest(
-				http.MethodPost, tc.path, strings.NewReader(tc.body),
-			))
-
-			require.Equal(t, http.StatusBadRequest, rr.Code)
-			require.Empty(t, migrator.requestCalls)
-		})
-	}
-}
-
-func TestMigrationControlHandlerExposesOnlyControlRoutes(t *testing.T) {
-	handler := migrationControlHandler(&migrationControlMigrator{})
-	for _, tc := range []struct {
-		method string
-		path   string
-		code   int
-	}{
-		{method: http.MethodGet, path: migrationRequestPath, code: http.StatusMethodNotAllowed},
-		{method: http.MethodGet, path: migrationFinalisationPath, code: http.StatusMethodNotAllowed},
-		{method: http.MethodGet, path: "/v1/enclave-info", code: http.StatusNotFound},
-		{method: http.MethodGet, path: "/health", code: http.StatusNotFound},
-		{method: http.MethodPost, path: "/unknown", code: http.StatusNotFound},
-	} {
-		rr := httptest.NewRecorder()
-		handler.ServeHTTP(rr, httptest.NewRequest(tc.method, tc.path, nil))
-		require.Equal(t, tc.code, rr.Code, "%s %s", tc.method, tc.path)
-	}
-}
-
-func TestMigrationControlServerLifecycle(t *testing.T) {
-	t.Run("closes listener with context", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		listener := newBlockingListener()
-		rt := newRuntimeState()
-		s := &servers{rt: rt}
-		s.serveMigrationControl(ctx, &migrationControlMigrator{}, listener)
-
-		waitTestSignal(t, listener.acceptStarted)
-		cancel()
-		waitTestSignal(t, listener.closed)
-	})
-
-	t.Run("reports listener failure", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		defer cancel()
-		rt := newRuntimeState()
-		s := &servers{rt: rt}
-		s.serveMigrationControl(
-			ctx,
-			&migrationControlMigrator{},
-			failingListener{err: errors.New("accept failed")},
-		)
-
-		err := waitTestResult(t, rt.ListenError())
-		require.ErrorContains(t, err, "accept failed")
-	})
-}
-
 func TestConfigureEnclaveInfoHandler(t *testing.T) {
 	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
 	t.Setenv("ENCLAVE_APP_NAME", "myapp")
@@ -545,35 +353,46 @@ func TestConfigureEnclaveInfoHandler(t *testing.T) {
 	nsm := &nsmW{nsm: &fakeNSM{session: newStatefulNSMSession(t, map[uint][]byte{
 		0: bytes.Repeat([]byte{0xab}, 48),
 	})}}
-	migrator, err := NewMigrator(
-		nsm, nil, ssm, newFakeS3(), nil, nil, migrationIntentTestBucket,
-	)
+	migrator, err := NewMigrator(nsm, ssm, newFakeS3(), migrationIntentTestBucket)
 	require.NoError(t, err)
 
 	err = s.ConfigureEnclaveInfoHandler(ctx, migrator, ssm)
 	require.NoError(t, err)
 
-	rr := httptest.NewRecorder()
-	s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/enclave-info", nil))
-
-	if rr.Code != http.StatusOK {
-		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
+	serve := func(t *testing.T) string {
+		t.Helper()
+		rr := httptest.NewRecorder()
+		s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/enclave-info", nil))
+		require.Equal(t, http.StatusOK, rr.Code)
+		return rr.Body.String()
 	}
-	want, err := json.Marshal(RuntimeInfo{
-		Version:                  Version,
-		PreviousPCR0:             "previous",
-		PreviousPCR0Attestation:  "attestation",
-		AttestationPubkey:        signer.Pubkey(),
-		Metrics:                  metrics.MetricsSnapshot(),
-		MigrationCooldownSeconds: 120,
-		Migration: &MigrationStatus{
-			State: migrationStateNone, SourcePCR0: strings.Repeat("ab", 48),
-		},
-		UpstreamApp:  rt.UpstreamAppInfo(),
-		KMSKeyLocked: true,
-	})
-	require.NoError(t, err)
-	require.JSONEq(t, string(want), rr.Body.String())
+	want := func(t *testing.T, status string) string {
+		t.Helper()
+		body, err := json.Marshal(RuntimeInfo{
+			Version:                  Version,
+			Status:                   status,
+			PreviousPCR0:             "previous",
+			PreviousPCR0Attestation:  "attestation",
+			AttestationPubkey:        signer.Pubkey(),
+			Metrics:                  metrics.MetricsSnapshot(),
+			MigrationCooldownSeconds: 120,
+			Migration: &MigrationStatus{
+				State: migrationStateNone, SourcePCR0: strings.Repeat("ab", 48),
+			},
+			UpstreamApp:  rt.UpstreamAppInfo(),
+			KMSKeyLocked: true,
+		})
+		require.NoError(t, err)
+		return string(body)
+	}
+
+	// Built with nil key material, so it is still awaiting a handoff.
+	require.JSONEq(t, want(t, runtimeStatusCandidate), serve(t))
+
+	// Promotion is visible on the same handler: it is registered once, before
+	// state exists, and the migrator is filled in underneath it.
+	migrator.Promote(&kmsW{keyID: "key"}, nil, nil)
+	require.JSONEq(t, want(t, runtimeStatusReady), serve(t))
 }
 
 func TestConfigureEnclaveInfoHandlerFailsClosedOnStatusError(t *testing.T) {

--- a/runtime/ssm.go
+++ b/runtime/ssm.go
@@ -22,6 +22,7 @@ type Param struct {
 
 type SSM interface {
 	Set(ctx context.Context, key, val string, opts ...SSMSetOption) error
+	SetIfAbsent(ctx context.Context, key, val string, opts ...SSMSetOption) (bool, error)
 	MustGet(ctx context.Context, key string) (string, error)
 	MayGet(ctx context.Context, key string) (string, error)
 	ListParams(ctx context.Context, prefix string) ([]Param, error)
@@ -44,6 +45,27 @@ func NewSSM(ssm SSMAPI) SSM {
 }
 
 func (s *ssmW) Set(ctx context.Context, key, val string, opts ...SSMSetOption) error {
+	_, err := s.put(ctx, key, val, true, opts...)
+	return err
+}
+
+// SetIfAbsent creates a parameter without overwriting an existing value. SSM
+// applies Overwrite=false atomically, so it can be used as a cross-process
+// write-once commit point.
+func (s *ssmW) SetIfAbsent(
+	ctx context.Context,
+	key, val string,
+	opts ...SSMSetOption,
+) (bool, error) {
+	return s.put(ctx, key, val, false, opts...)
+}
+
+func (s *ssmW) put(
+	ctx context.Context,
+	key, val string,
+	overwrite bool,
+	opts ...SSMSetOption,
+) (bool, error) {
 	so := &SSMSetOptions{tier: ssmtypes.ParameterTierStandard}
 
 	for _, opt := range opts {
@@ -54,12 +76,16 @@ func (s *ssmW) Set(ctx context.Context, key, val string, opts ...SSMSetOption) e
 		Name:      aws.String(key),
 		Value:     aws.String(val),
 		Type:      ssmtypes.ParameterTypeString,
-		Overwrite: aws.Bool(true),
+		Overwrite: aws.Bool(overwrite),
 		Tier:      so.tier,
 	}); err != nil {
-		return fmt.Errorf("ssm put-parameter %s: %w", key, err)
+		var exists *ssmtypes.ParameterAlreadyExists
+		if !overwrite && errors.As(err, &exists) {
+			return false, nil
+		}
+		return false, fmt.Errorf("ssm put-parameter %s: %w", key, err)
 	}
-	return nil
+	return true, nil
 }
 
 func (s *ssmW) MustGet(ctx context.Context, key string) (string, error) {

--- a/runtime/ssm_test.go
+++ b/runtime/ssm_test.go
@@ -2,12 +2,30 @@ package runtime
 
 import (
 	"context"
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ssm"
 	ssmtypes "github.com/aws/aws-sdk-go-v2/service/ssm/types"
 	"github.com/stretchr/testify/require"
 )
+
+type atomicPutSSM struct {
+	fakeSSM
+	mu sync.Mutex
+}
+
+func (f *atomicPutSSM) PutParameter(
+	ctx context.Context,
+	in *ssm.PutParameterInput,
+	opts ...func(*ssm.Options),
+) (*ssm.PutParameterOutput, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.fakeSSM.PutParameter(ctx, in, opts...)
+}
 
 func TestSSMSetAndGet(t *testing.T) {
 	ctx := context.Background()
@@ -21,6 +39,44 @@ func TestSSMSetAndGet(t *testing.T) {
 	if got != "two" {
 		t.Fatalf("got %q, want %q", got, "two")
 	}
+}
+
+func TestSSMSetIfAbsentIsAtomic(t *testing.T) {
+	ctx := context.Background()
+	api := &atomicPutSSM{}
+	store := NewSSM(api)
+
+	const contenders = 32
+	results := make(chan bool, contenders)
+	errs := make(chan error, contenders)
+	var wg sync.WaitGroup
+	for i := range contenders {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			created, err := store.SetIfAbsent(ctx, "/app/commit", fmt.Sprintf("key-%d", i))
+			results <- created
+			errs <- err
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	winners := 0
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	for created := range results {
+		if created {
+			winners++
+		}
+	}
+	require.Equal(t, 1, winners)
+
+	got, err := store.MustGet(ctx, "/app/commit")
+	require.NoError(t, err)
+	require.Contains(t, got, "key-")
 }
 
 func TestSSMGet(t *testing.T) {

--- a/runtime/ssm_ttl_cache.go
+++ b/runtime/ssm_ttl_cache.go
@@ -35,6 +35,23 @@ func (s *ssmTTLCache) Set(ctx context.Context, key, val string, opts ...SSMSetOp
 	return nil
 }
 
+func (s *ssmTTLCache) SetIfAbsent(
+	ctx context.Context,
+	key, val string,
+	opts ...SSMSetOption,
+) (bool, error) {
+	created, err := s.ssm.SetIfAbsent(ctx, key, val, opts...)
+	if err != nil {
+		return false, err
+	}
+	if created {
+		s.mu.Lock()
+		delete(s.cache, key)
+		s.mu.Unlock()
+	}
+	return created, nil
+}
+
 func (s *ssmTTLCache) MustGet(ctx context.Context, key string) (string, error) {
 	if val, ok := s.get(key); ok {
 		return val, nil

--- a/runtime/state.go
+++ b/runtime/state.go
@@ -5,9 +5,11 @@ import (
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
+	"time"
 
 	"github.com/fxamacker/cbor/v2"
 )
@@ -21,6 +23,11 @@ const (
 	purposeStateOrigin         = "enclave.state_origin"
 	purposeMigrationTransition = "enclave.state_origin.migration_transition"
 )
+
+// errAwaitingHandoff means this enclave holds no state and is not permitted to
+// create the deployment: it is a candidate, and must wait for a predecessor to
+// commit to it. Distinct from every other load failure, which stays fatal.
+var errAwaitingHandoff = errors.New("awaiting migration handoff")
 
 type startState int
 
@@ -122,6 +129,46 @@ func WriteTransitionReceipt(
 	)
 }
 
+const (
+	handoffPollMin = time.Second
+	handoffPollMax = 30 * time.Second
+)
+
+// establishStateAwaitingHandoff establishes state, waiting rather than failing
+// while this enclave is a candidate. Only errAwaitingHandoff waits; every other
+// failure is fatal, so a genuinely broken enclave still dies loudly instead of
+// hanging. There is deliberately no timeout: a candidate legitimately sits until
+// an operator migrates to it, and giving up would only force a fresh challenge
+// exchange after a needless restart.
+func establishStateAwaitingHandoff(
+	ctx context.Context,
+	nsm NSM,
+	kmsAPI KMSAPI,
+	sts STSAPI,
+	ssm SSM,
+) (verifiedState, error) {
+	backoff := handoffPollMin
+	for {
+		verified, err := EstablishState(ctx, nsm, kmsAPI, sts, ssm)
+		if !errors.Is(err, errAwaitingHandoff) {
+			return verified, err
+		}
+
+		if backoff == handoffPollMin {
+			slog.Info("candidate: awaiting migration handoff")
+		}
+
+		select {
+		case <-ctx.Done():
+			return verifiedState{}, ctx.Err()
+		case <-time.After(backoff):
+		}
+		if backoff < handoffPollMax {
+			backoff = min(backoff*2, handoffPollMax)
+		}
+	}
+}
+
 func loadUnverifiedState(
 	ctx context.Context,
 	ssm SSM,
@@ -184,6 +231,9 @@ func loadUnverifiedState(
 	}
 
 	if keyID == "" {
+		if getPreviousPCR0() != "genesis" {
+			return unverifiedState{}, errAwaitingHandoff
+		}
 		if hasPredecessor {
 			return unverifiedState{}, fmt.Errorf("genesis state has predecessor artifacts")
 		}

--- a/runtime/state_test.go
+++ b/runtime/state_test.go
@@ -77,7 +77,57 @@ func TestStateRootIsOwnerPCR0Scoped(t *testing.T) {
 	require.ErrorContains(t, err, "no owner PCR0")
 }
 
-func TestEstablishStateRefusesSuccessorBeforeHandoff(t *testing.T) {
+func TestGenesisRequiresTheGenesisSentinel(t *testing.T) {
+	// Set before the table: the param paths below are built from these.
+	setStateOriginTestEnv(t)
+
+	pcr0 := bytes.Repeat([]byte{0xab}, 48)
+	pcr0Hex := hex.EncodeToString(pcr0)
+	otherPCR0 := hex.EncodeToString(bytes.Repeat([]byte{0x99}, 48))
+
+	for _, tc := range []struct {
+		name         string
+		previousPCR0 string
+		params       map[string]string
+		wantStart    startState
+		wantErr      error
+	}{
+		{
+			name:         "genesis image creates the deployment",
+			previousPCR0: "genesis",
+			wantStart:    startStateGenesis,
+		},
+		{
+			name:         "a successor waits to be handed state",
+			previousPCR0: otherPCR0,
+			wantErr:      errAwaitingHandoff,
+		},
+		{
+			name:         "a successor waits even alongside another generation",
+			previousPCR0: otherPCR0,
+			params:       map[string]string{kmsKeyIDParam(otherPCR0): "someone-elses-key"},
+			wantErr:      errAwaitingHandoff,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			setStateOriginTestEnv(t)
+			t.Setenv("ENCLAVE_PREVIOUS_PCR0", tc.previousPCR0)
+
+			fake, ssm := stateOriginTestSSM(tc.params)
+			got, err := loadUnverifiedState(context.Background(), ssm, pcr0)
+
+			if tc.wantErr != nil {
+				require.ErrorIs(t, err, tc.wantErr)
+				require.Empty(t, fake.params[kmsKeyIDParam(pcr0Hex)])
+				return
+			}
+			require.NoError(t, err)
+			require.Equal(t, tc.wantStart, got.startState)
+		})
+	}
+}
+
+func TestEstablishStateAwaitsHandoffWithoutMintingAKey(t *testing.T) {
 	setStateOriginTestEnv(t)
 	// A successor's measurement names its predecessor; only a first enclave
 	// carries "genesis".
@@ -87,7 +137,6 @@ func TestEstablishStateRefusesSuccessorBeforeHandoff(t *testing.T) {
 	fake, ssm := stateOriginTestSSM(nil)
 	kmsf := newFakeKMS()
 
-	// Nothing is scoped to this PCR0 yet: the predecessor has not finalised.
 	_, err := EstablishState(
 		context.Background(),
 		&nsmW{nsm: &fakeNSM{session: newStatefulNSMSession(t, map[uint][]byte{0: pcr0})}},
@@ -96,11 +145,11 @@ func TestEstablishStateRefusesSuccessorBeforeHandoff(t *testing.T) {
 		ssm,
 	)
 
-	require.ErrorContains(t, err, "previous PCR0 is required")
-	require.Empty(t, fake.params[kmsKeyIDParam(hex.EncodeToString(pcr0))],
-		"a successor that boots early must not fall through to genesis")
+	// A candidate waits; it must not quietly become its own genesis.
+	require.ErrorIs(t, err, errAwaitingHandoff)
+	require.Empty(t, fake.params[kmsKeyIDParam(hex.EncodeToString(pcr0))])
 	kmsf.mu.Lock()
-	require.Empty(t, kmsf.keys, "no key may be minted for an early successor")
+	require.Empty(t, kmsf.keys, "no key may be minted while awaiting a handoff")
 	kmsf.mu.Unlock()
 }
 
@@ -633,6 +682,9 @@ func setStateOriginTestEnv(t *testing.T) {
 	t.Helper()
 	t.Setenv("ENCLAVE_DEPLOYMENT", "prod")
 	t.Setenv("ENCLAVE_APP_NAME", "state-origin")
+	// Most of these fixtures exercise a deployment this enclave created.
+	// Cases about candidacy override it.
+	t.Setenv("ENCLAVE_PREVIOUS_PCR0", "genesis")
 	t.Setenv("ENCLAVE_SECRETS_CONFIG", `[
 		{"name":"alpha","env_var":"ALPHA"},
 		{"name":"beta","env_var":"BETA"}

--- a/runtime/utils_test.go
+++ b/runtime/utils_test.go
@@ -67,6 +67,11 @@ func (f *fakeSSM) PutParameter(
 	if f.params == nil {
 		f.params = map[string]string{}
 	}
+	if !aws.ToBool(in.Overwrite) {
+		if _, exists := f.params[aws.ToString(in.Name)]; exists {
+			return nil, &ssmtypes.ParameterAlreadyExists{}
+		}
+	}
 	f.params[aws.ToString(in.Name)] = aws.ToString(in.Value)
 	return &ssm.PutParameterOutput{}, nil
 }
@@ -151,6 +156,27 @@ func (f *fakeSSM) Set(_ context.Context, key, val string, _ ...SSMSetOption) err
 	}
 	f.params[key] = val
 	return nil
+}
+
+func (f *fakeSSM) SetIfAbsent(
+	_ context.Context,
+	key, val string,
+	_ ...SSMSetOption,
+) (bool, error) {
+	if f.err != nil {
+		return false, f.err
+	}
+	if err := f.putErrs[key]; err != nil {
+		return false, err
+	}
+	if f.params == nil {
+		f.params = map[string]string{}
+	}
+	if _, exists := f.params[key]; exists {
+		return false, nil
+	}
+	f.params[key] = val
+	return true, nil
 }
 
 func (f *fakeSSM) MustGet(_ context.Context, key string) (string, error) {


### PR DESCRIPTION
## Summary

This PR replaces the host-controlled migration API with an autonomous, attestation-based blue/green migration flow between enclaves.

Booting a successor candidate now acts as the migration request. The predecessor discovers it through SSM, verifies its live NSM attestation, records the migration intent, and commits the state handoff after the configured cooldown.

## What changed

- Boot successor enclaves in a restricted `candidate` state.
- Discover successors through an SSM challenge-response protocol.
- Derive the successor PCR0 directly from its verified NSM attestation.
- Promote candidates in place after the predecessor commits their state.
- Remove the unauthenticated migration HTTP endpoint and QEMU migration proxy.
- Add an operator-controlled SSM abort mechanism during the cooldown.
- Use an atomic create-only SSM write so horizontally scaled predecessors cannot overwrite an existing handoff.
- Ensure the expected predecessor PCR0 is measured into the successor EIF.
- Update documentation and E2E coverage for the new migration lifecycle.

## Migration flow

1. The operator builds and boots the successor EIF.
2. The successor starts as a candidate without application state or traffic.
3. The predecessor publishes a fresh challenge through SSM.
4. The candidate answers with an NSM attestation containing the challenge.
5. The predecessor verifies the attestation and records an Object-Locked migration intent.
6. After the cooldown, the predecessor re-encrypts the state for the successor PCR0 and atomically commits the handoff.
7. The successor verifies and adopts the state, then promotes itself without restarting.

If multiple candidates answer simultaneously, the predecessor treats the migration as ambiguous and does not proceed.

## Security model

Only the operator can deploy a candidate into the deployment environment, so booting that candidate is the authorization decision.

NSM attestation ensures the predecessor learns the genuine PCR0 of a live enclave rather than accepting a host-supplied value. The nonce prevents replay, while the atomic SSM commit ensures only one predecessor replica can finalize a handoff.

## Testing

- `make test`
- `go test -race ./...`
- `go vet ./...`
- `nix build .#checks.x86_64-linux.e2e --no-link --print-build-logs`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ArkLabsHQ/codesmith/enclave/pr/161"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790409875&installation_model_id=433183&pr_number=161&repository=ArkLabsHQ%2Fenclave&return_to=https%3A%2F%2Fgithub.com%2FArkLabsHQ%2Fenclave%2Fpull%2F161&signature=edd9c811b18cda9bfd4f29c74c7492fe4818b8bf5290c27c0003bd1042dd78fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->