### PR TITLE
fix(nix): set meta.mainProgram on the cli derivation

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,10 @@
                   ldflags = [
                     "-X main.Version=${finalAttrs.version}"
                   ];
+
+                  # subPackages installs cmd/enclave as bin/enclave, but nix run derives
+                  # the program name from pname and would look for bin/enclave-cli.
+                  meta.mainProgram = "enclave";
                 });
                 default = self.packages.${system}.cli;
               }


### PR DESCRIPTION
`nix run` on the CLI fails, including the command in the README's Quickstart:

```
$ nix run github:ArkLabsHQ/enclave -- --version
error: unable to execute '/nix/store/...-enclave-cli-0.1.0/bin/enclave-cli':
       No such file or directory
```

`subPackages = [ "cmd/enclave" ]` installs the binary as `bin/enclave`, but with no
`meta.mainProgram` set, `nix run` derives the program name from `pname` and looks for
`bin/enclave-cli`.

Since that is the attestation-verification command the README tells people to run, the
documented way to verify a running enclave does not currently work.

Setting `meta.mainProgram` rather than renaming `pname` keeps the derivation name and
store path unchanged.

## Verified

```
# before, on master
$ nix run github:ArkLabsHQ/enclave -- --version
error: unable to execute '.../bin/enclave-cli': No such file or directory

# after, on this branch
$ nix run .# -- --version
enclave version 0.1.0

$ nix run .# -- curl --help
Verifies the enclave's Nitro attestation and PCR0, binds the live TLS
certificate to the attestation document, ...
```

Found while verifying a real deployment: the CLI itself works fine, only its `nix run`
wiring was broken, so the workaround was invoking the store path directly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ArkLabsHQ/codesmith/enclave/pr/162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790414436&installation_model_id=433183&pr_number=162&repository=ArkLabsHQ%2Fenclave&return_to=https%3A%2F%2Fgithub.com%2FArkLabsHQ%2Fenclave%2Fpull%2F162&signature=436ba28fc94d4c70d02705db2a7cb5b74edd3cb5eba74e11496831204993ef81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->