### PR TITLE
fix(runtime): stop claiming the whole /v1 subtree on the external mux

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,6 @@ measurement. A subset can be overridden at runtime from SSM.
 | `ENCLAVE_NITRIDING_UPSTREAM` | `auto` | Runtime-to-application HTTP version. `h1` pins HTTP/1.1, `h2c` pins HTTP/2 cleartext and is required for gRPC, `auto` matches the inbound request. |
 | `ENCLAVE_NITRIDING_FQDN` | `localhost` | Hostname for the TLS certificate. |
 | `ENCLAVE_NITRIDING_HOST_PROXY_PORT` | `1024` | Host vsock port where gvproxy listens. |
-| `ENCLAVE_NITRIDING_DEBUG` | `false` | Reported by `GET /enclave/config`. |
 | `ENCLAVE_VIPROXY_ENABLED` | `true` | Set to `false` to disable the in-process IMDS forwarder. |
 | `ENCLAVE_VIPROXY_IN_ADDRS` | `127.0.0.1:80` | IMDS forwarder listen address. |
 | `ENCLAVE_VIPROXY_OUT_ADDRS` | `3:8002` | IMDS forwarder target, `CID:PORT` or `host:port`. |
@@ -381,13 +380,13 @@ With `D` = deployment, `A` = app name, `L` = `locked` or `unlocked`:
 
 TLS 1.2 minimum. Every non-gRPC response carries `X-Attestation-Signature` and
 `X-Attestation-Pubkey`, a BIP-340 Schnorr signature over the SHA-256 of the
-response body. `/enclave/v1/*` responses also carry permissive CORS headers.
+response body. `/enclave/*` responses also carry permissive CORS headers, and
+an `OPTIONS` preflight to any path in that namespace is answered `204` by the
+runtime.
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
 | GET | `/enclave/attestation?nonce=<40 hex>` | none | NSM attestation document, base64. The nonce is mandatory and echoed back. |
-| GET | `/enclave` | none | Human-readable index. |
-| GET | `/enclave/config` | none | Effective runtime configuration as JSON. |
 | GET | `/enclave/v1/info` | none | Version, PCR0, predecessor PCR0 and attestation, attestation public key, migration status, application status. |
 | GET | `/health` | none | `{"status":"ready"}` once the application has been started, `{"status":"initializing"}` with status 503 before. |
 | GET | `/enclave/v1/metrics` | none | Metric snapshot. |
@@ -396,12 +395,14 @@ response body. `/enclave/v1/*` responses also carry permissive CORS headers.
 | POST | `/enclave/v1/metrics` | bearer | OTLP protobuf metrics ingest, 1 MiB limit. |
 | POST | `/enclave/v1/logs` | bearer | OTLP protobuf logs ingest, 1 MiB limit. |
 | POST | `/enclave/v1/traces` | bearer | OTLP protobuf spans ingest, 1 MiB limit. |
-| any | unmatched paths outside `/enclave/v1/*` | none | Reverse-proxied to the application. |
+| any | unmatched paths outside the `/enclave` namespace | none | Reverse-proxied to the application. |
 
 Bearer endpoints expect `Authorization: Bearer <ENCLAVE_RUNTIME_TOKEN>`.
 
-The `/enclave/v1/` subtree is reserved for runtime APIs. Unknown paths beneath
-it return the runtime's `404` response and are never proxied to the application.
+The complete `/enclave` namespace is reserved for runtime APIs. Unknown
+non-preflight paths beneath it return the runtime's `404` response, and no
+request in that namespace is proxied to the application. A request to the bare
+`/enclave` is redirected to `/enclave/`, which then returns that `404`.
 
 `/health` reports ready as soon as the application process has been started,
 which is marginally before it binds its port. Readiness probes should target an

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Provide the resulting EIF to a Nitro-capable host that satisfies the
 client:
 
 ```sh
-nix run github:ArkLabsHQ/enclave -- curl /v1/enclave-info \
+nix run github:ArkLabsHQ/enclave -- curl /enclave/v1/info \
   --base-url https://enclave.example.com \
   --expected-pcr0 "$(jq -r .PCR0 result/pcr.json)"
 ```
@@ -381,24 +381,27 @@ With `D` = deployment, `A` = app name, `L` = `locked` or `unlocked`:
 
 TLS 1.2 minimum. Every non-gRPC response carries `X-Attestation-Signature` and
 `X-Attestation-Pubkey`, a BIP-340 Schnorr signature over the SHA-256 of the
-response body. `/v1/*` responses also carry permissive CORS headers.
+response body. `/enclave/v1/*` responses also carry permissive CORS headers.
 
 | Method | Path | Auth | Purpose |
 |---|---|---|---|
 | GET | `/enclave/attestation?nonce=<40 hex>` | none | NSM attestation document, base64. The nonce is mandatory and echoed back. |
 | GET | `/enclave` | none | Human-readable index. |
 | GET | `/enclave/config` | none | Effective runtime configuration as JSON. |
-| GET | `/v1/enclave-info` | none | Version, PCR0, predecessor PCR0 and attestation, attestation public key, migration status, application status. |
+| GET | `/enclave/v1/info` | none | Version, PCR0, predecessor PCR0 and attestation, attestation public key, migration status, application status. |
 | GET | `/health` | none | `{"status":"ready"}` once the application has been started, `{"status":"initializing"}` with status 503 before. |
-| GET | `/v1/enclave-metrics` | none | Metric snapshot. |
-| GET | `/v1/enclave-logs` | none | Buffered logs. Accepts `since`, `level`, `limit`. |
-| GET | `/v1/enclave-traces` | none | Buffered spans. Accepts `since`, `limit`, `service`. |
-| POST | `/v1/metrics` | bearer | OTLP protobuf metrics ingest, 1 MiB limit. |
-| POST | `/v1/logs` | bearer | OTLP protobuf logs ingest, 1 MiB limit. |
-| POST | `/v1/traces` | bearer | OTLP protobuf spans ingest, 1 MiB limit. |
-| any | everything else | none | Reverse-proxied to the application. |
+| GET | `/enclave/v1/metrics` | none | Metric snapshot. |
+| GET | `/enclave/v1/logs` | none | Buffered logs. Accepts `since`, `level`, `limit`. |
+| GET | `/enclave/v1/traces` | none | Buffered spans. Accepts `since`, `limit`, `service`. |
+| POST | `/enclave/v1/metrics` | bearer | OTLP protobuf metrics ingest, 1 MiB limit. |
+| POST | `/enclave/v1/logs` | bearer | OTLP protobuf logs ingest, 1 MiB limit. |
+| POST | `/enclave/v1/traces` | bearer | OTLP protobuf spans ingest, 1 MiB limit. |
+| any | unmatched paths outside `/enclave/v1/*` | none | Reverse-proxied to the application. |
 
 Bearer endpoints expect `Authorization: Bearer <ENCLAVE_RUNTIME_TOKEN>`.
+
+The `/enclave/v1/` subtree is reserved for runtime APIs. Unknown paths beneath
+it return the runtime's `404` response and are never proxied to the application.
 
 `/health` reports ready as soon as the application process has been started,
 which is marginally before it binds its port. Readiness probes should target an
@@ -406,9 +409,11 @@ application endpoint.
 
 ### Internal listener, TCP 127.0.0.1:8080
 
-Serves `/v1/*` and `/health` only, with the same handlers and authentication.
+Serves `/v1/metrics`, `/v1/logs`, `/v1/traces`, and `/health` only, with the
+same handlers and authentication. The HTTP method selects metric, log, and trace
+ingest (POST) or readback (GET).
 This is the endpoint advertised to the application through
-`ENCLAVE_PROXY_PORT`. It does not serve `/v1/enclave-info`, the `/enclave/*`
+`ENCLAVE_PROXY_PORT`. It does not serve `/enclave/v1/info`, the `/enclave/*`
 endpoints, or the application proxy.
 
 ### Migration control, vsock :8003
@@ -497,7 +502,7 @@ The order is:
      http://<migration-control-endpoint>/request-migration
    ```
    This writes an Object-Locked record to the intent log. It cannot be deleted.
-4. Wait for the cooldown. Poll `/v1/enclave-info` until
+4. Wait for the cooldown. Poll `/enclave/v1/info` until
    `migration.state == "eligible"`.
 5. Finalise:
    ```sh
@@ -514,7 +519,7 @@ The order is:
 7. Boot the successor. It verifies the predecessor attestation, the PCR31
    commitment, the key policy, and the transition receipt before adopting the
    state.
-8. Confirm adoption on the successor's `/v1/enclave-info`:
+8. Confirm adoption on the successor's `/enclave/v1/info`:
    `previous_pcr0` equals the predecessor PCR0,
    `previous_pcr0_attestation` is non-empty, and `migration.source_pcr0` equals
    the successor's own PCR0.
@@ -549,7 +554,7 @@ The Nix derivation is named `enclave-cli`; the installed binary is `enclave`.
 
 ```sh
 # Runtime and migration status.
-enclave curl /v1/enclave-info \
+enclave curl /enclave/v1/info \
   --base-url https://enclave.example.com --expected-pcr0 834837d8...9ba9
 
 # Authenticated POST.

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -112,7 +112,7 @@ func TestClientBootstrapPinSequencing(t *testing.T) {
 			Options{ExpectedPCR0: pcr0, InsecureSkipCOSEVerify: true, SkipKeyBinding: true},
 		)
 		require.NoError(t, err)
-		resp, err := c.Get(context.Background(), "/v1/enclave-info")
+		resp, err := c.Get(context.Background(), "/enclave/v1/info")
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
@@ -126,7 +126,7 @@ func TestClientBootstrapPinSequencing(t *testing.T) {
 		// Strict default: a missing signing key is a hard failure (no silent skip).
 		strict, err := New(srv.URL, Options{ExpectedPCR0: pcr0, InsecureSkipCOSEVerify: true})
 		require.NoError(t, err)
-		_, err = strict.Get(context.Background(), "/v1/enclave-info")
+		_, err = strict.Get(context.Background(), "/enclave/v1/info")
 		require.ErrorContains(t, err, "attestation key not yet registered")
 
 		// Explicit PCR0 + pin only: proceeds (this is curl's mode).
@@ -135,7 +135,7 @@ func TestClientBootstrapPinSequencing(t *testing.T) {
 			Options{ExpectedPCR0: pcr0, InsecureSkipCOSEVerify: true, SkipKeyBinding: true},
 		)
 		require.NoError(t, err)
-		_, err = lite.Get(context.Background(), "/v1/enclave-info")
+		_, err = lite.Get(context.Background(), "/enclave/v1/info")
 		require.NoError(t, err)
 	})
 
@@ -153,7 +153,7 @@ func TestClientBootstrapPinSequencing(t *testing.T) {
 			Options{ExpectedPCR0: pcr0, InsecureSkipCOSEVerify: true, SkipKeyBinding: true},
 		)
 		require.NoError(t, err)
-		_, err = c.Get(context.Background(), "/v1/enclave-info")
+		_, err = c.Get(context.Background(), "/enclave/v1/info")
 		require.ErrorContains(t, err, "TLS cert fingerprint mismatch")
 		fe.mu.Lock()
 		defer fe.mu.Unlock()

--- a/client/verify.go
+++ b/client/verify.go
@@ -19,7 +19,7 @@ import (
 	"github.com/hf/nitrite"
 )
 
-// enclaveInfoResponse is the JSON structure returned by /v1/enclave-info.
+// enclaveInfoResponse is the JSON structure returned by /enclave/v1/info.
 type enclaveInfoResponse struct {
 	Version           string `json:"version"`
 	PreviousPCR0      string `json:"previous_pcr0"`
@@ -216,7 +216,7 @@ func verifyLeafCertPin(rawCerts [][]byte, expectedHashHex string) error {
 }
 
 // verifyKeyBinding verifies the enclave's ephemeral attestation key by
-// checking that the pubkey from /v1/enclave-info matches the signingKeyHash
+// checking that the pubkey from /enclave/v1/info matches the signingKeyHash
 // in the attestation document's UserData.
 func verifyKeyBinding(
 	ctx context.Context,
@@ -341,13 +341,13 @@ func verifySchnorrSignature(body []byte, sigHex, attestPubkeyHex string) error {
 	return nil
 }
 
-// fetchEnclaveInfo fetches the /v1/enclave-info endpoint.
+// fetchEnclaveInfo fetches the /enclave/v1/info endpoint.
 func fetchEnclaveInfo(
 	ctx context.Context,
 	httpClient *http.Client,
 	baseURL string,
 ) (*enclaveInfoResponse, error) {
-	infoURL := strings.TrimRight(baseURL, "/") + "/v1/enclave-info"
+	infoURL := strings.TrimRight(baseURL, "/") + "/enclave/v1/info"
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, infoURL, nil)
 	if err != nil {
 		return nil, err

--- a/cmd/enclave/curl.go
+++ b/cmd/enclave/curl.go
@@ -30,7 +30,7 @@ func newCurlCommand() *cobra.Command {
 certificate to the attestation document, then makes the requested call. The
 response must carry a valid enclave response signature.
 
-Use /v1/enclave-info for runtime, status, and migration information.`,
+Use /enclave/v1/info for runtime, status, and migration information.`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runCurl(cmd, curlOptions{

--- a/nix/tests/e2e.py
+++ b/nix/tests/e2e.py
@@ -165,7 +165,7 @@ blue.succeed(
 )
 blue_secret = secret_value(blue)
 blue.succeed(
-    "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
+    "curl -skf --http1.1 https://127.0.0.1/enclave/v1/info "
     f"| jq -e --arg p '{BLUE_PCR0}' "
     "'.previous_pcr0 == \"genesis\" and .migration.state == \"none\" "
     "and .migration.source_pcr0 == $p'"
@@ -313,7 +313,7 @@ assert (
     >= 1
 )
 blue.wait_until_succeeds(
-    "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
+    "curl -skf --http1.1 https://127.0.0.1/enclave/v1/info "
     "| jq -e '.migration.state == \"eligible\"'",
     timeout=120,
 )
@@ -372,7 +372,7 @@ green.wait_for_unit("enclave-start.service")
 wait_healthy(green)
 assert secret_value(green) == blue_secret
 green.succeed(
-    "curl -skf --http1.1 https://127.0.0.1/v1/enclave-info "
+    "curl -skf --http1.1 https://127.0.0.1/enclave/v1/info "
     f"| jq -e --arg prev '{BLUE_PCR0}' --arg current '{GREEN_PCR0}' "
     "'.previous_pcr0 == $prev "
     "and (.previous_pcr0_attestation | length) > 0 "

--- a/runtime/config.go
+++ b/runtime/config.go
@@ -10,23 +10,17 @@ import (
 )
 
 // Config holds runtime HTTP/network settings.
-// Q: Many of these fields are not set from env vars, are they dead code?
 type Config struct {
-	FQDN              string   // Hostname the TLS cert is issued for.
-	ExtPort           uint16   // External TLS listener.
-	DisableKeepAlives bool     // Disable HTTP keep-alives on the TLS server.
-	IntPort           uint16   // Internal loopback HTTP listener.
-	HostProxyPort     uint32   // Vsock port the host-side gvproxy listens on.
-	UseACME           bool     // Use ACME instead of self-signed TLS.
-	ACMEDirectory     string   // ACME dir override: "letsencrypt-staging" or https:// URL.
-	ACMEEmail         string   // Optional ACME account contact email.
-	ACMECA            string   // PEM CA bundle for private/test ACME HTTPS.
-	Debug             bool     // Verbose runtime logging.
-	FdCur, FdMax      uint64   // File-descriptor soft/hard limits.
-	AppURL            *url.URL // Public source URL of the user app (informational).
-	AppWebSrv         *url.URL // Loopback URL the catch-all revProxy forwards to.
-	UpstreamProtocol  string   // revProxy-to-app HTTP version: auto (match inbound), h2c, or h1.
-	MockCertFp        string   // Test-only TLS cert fingerprint override.
+	FQDN             string   // Hostname the TLS cert is issued for.
+	ExtPort          uint16   // External TLS listener.
+	IntPort          uint16   // Internal loopback HTTP listener.
+	HostProxyPort    uint32   // Vsock port the host-side gvproxy listens on.
+	UseACME          bool     // Use ACME instead of self-signed TLS.
+	ACMEDirectory    string   // ACME dir override: "letsencrypt-staging" or https:// URL.
+	ACMEEmail        string   // Optional ACME account contact email.
+	ACMECA           string   // PEM CA bundle for private/test ACME HTTPS.
+	AppWebSrv        *url.URL // Loopback URL the catch-all revProxy forwards to.
+	UpstreamProtocol string   // revProxy-to-app HTTP version: auto (match inbound), h2c, or h1.
 }
 
 // LoadConfig builds Config from ENCLAVE_* env vars.
@@ -58,7 +52,6 @@ func LoadConfig() (*Config, error) {
 		HostProxyPort:    hostProxyPort,
 		AppWebSrv:        appWebSrv,
 		UpstreamProtocol: strings.ToLower(envDefault("ENCLAVE_NITRIDING_UPSTREAM", "auto")),
-		Debug:            strings.EqualFold(os.Getenv("ENCLAVE_NITRIDING_DEBUG"), "true"),
 	}
 	return cfg, nil
 }

--- a/runtime/logging.go
+++ b/runtime/logging.go
@@ -240,7 +240,7 @@ func (l *Logging) StartCloudWatchExport(ctx context.Context) error {
 	return nil
 }
 
-// HandleLogsPost accepts OTLP protobuf logs.
+// HandleLogsPost accepts OTLP protobuf logs over POST.
 func HandleLogsPost(l *Logging) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		body := http.MaxBytesReader(w, r.Body, 1<<20) // 1MB limit
@@ -291,7 +291,7 @@ func HandleLogsPost(l *Logging) http.HandlerFunc {
 	}
 }
 
-// handleLogsGet returns buffered logs; read-only/no auth.
+// handleLogsGet returns buffered logs over GET; read-only/no auth.
 func handleLogsGet(l *Logging) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var since time.Time

--- a/runtime/logging_test.go
+++ b/runtime/logging_test.go
@@ -168,7 +168,7 @@ func TestLogHandlers(t *testing.T) {
 			logging,
 		)(
 			w,
-			httptest.NewRequest(http.MethodGet, "/v1/enclave-logs?level=error", nil),
+			httptest.NewRequest(http.MethodGet, "/v1/logs?level=error", nil),
 		)
 
 		require.Equal(t, http.StatusOK, w.Code)

--- a/runtime/metrics.go
+++ b/runtime/metrics.go
@@ -287,7 +287,7 @@ func readProcMeminfo() (map[string]float64, error) {
 }
 
 // HandleMetricGet returns a JSON snapshot of all metrics.
-// GET /v1/enclave-metrics
+// GET /enclave/v1/metrics externally; GET /v1/metrics on the internal listener.
 func HandleMetricGet(metrics *Metrics) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")

--- a/runtime/metrics_test.go
+++ b/runtime/metrics_test.go
@@ -121,7 +121,7 @@ func TestMetricHandlers(t *testing.T) {
 		metrics.SetAppMetric("custom", 2)
 		w := httptest.NewRecorder()
 
-		HandleMetricGet(metrics)(w, httptest.NewRequest(http.MethodGet, "/v1/enclave-metrics", nil))
+		HandleMetricGet(metrics)(w, httptest.NewRequest(http.MethodGet, "/v1/metrics", nil))
 
 		require.Equal(t, http.StatusOK, w.Code)
 		require.JSONEq(t, `{

--- a/runtime/network.go
+++ b/runtime/network.go
@@ -37,7 +37,7 @@ func StartNetorking(ctx context.Context, cfg Config) error {
 	}
 
 	if nitriding.InEnclave() {
-		if err := nitriding.SetFdLimit(cfg.FdCur, cfg.FdMax); err != nil {
+		if err := nitriding.SetFdLimit(0, 0); err != nil {
 			slog.Warn("set fd limit", "error", err)
 		}
 		if err := nitriding.ConfigureLoIface(); err != nil {

--- a/runtime/servers.go
+++ b/runtime/servers.go
@@ -31,6 +31,7 @@ const (
 	migrationControlPort      = 8003
 	migrationRequestPath      = "/request-migration"
 	migrationFinalisationPath = "/finalise-migration"
+	externalRuntimeV1Prefix   = "/enclave/v1/"
 )
 
 var (
@@ -53,22 +54,12 @@ type servers struct {
 	ext     *http.Server
 	int     *http.Server
 	sm      *http.ServeMux
+	rm      *http.ServeMux
 	im      *http.ServeMux
 	em      *http.ServeMux
 	rt      RuntimeState
 	signer  AttestedSigner
 	metrics *Metrics
-}
-
-// runtimeV1Paths are the runtime's own endpoints beneath /v1. Everything else under
-// /v1 belongs to the application and is proxied to it.
-var runtimeV1Paths = []string{
-	"/v1/metrics",
-	"/v1/enclave-metrics",
-	"/v1/logs",
-	"/v1/enclave-logs",
-	"/v1/traces",
-	"/v1/enclave-traces",
 }
 
 func SetupHttpServers(
@@ -102,30 +93,19 @@ func SetupHttpServers(
 	}
 
 	sm := http.NewServeMux()
-	sm.HandleFunc("POST /v1/metrics", withTokenAuth(authToken, HandleMetricPost(metrics)))
-	sm.HandleFunc("GET /v1/enclave-metrics", HandleMetricGet(metrics))
+	registerRuntimeV1Handlers(sm, "/v1/", metrics, logging, tracing, authToken)
 	sm.Handle("GET /health", healthHandler(rt))
-	sm.HandleFunc("POST /v1/logs", withTokenAuth(authToken, HandleLogsPost(logging)))
-	sm.HandleFunc("GET /v1/enclave-logs", handleLogsGet(logging))
-	sm.HandleFunc("POST /v1/traces", withTokenAuth(authToken, HandleTracingPost(tracing)))
-	sm.HandleFunc("GET /v1/enclave-traces", HandleTracingGet(tracing))
+
+	rm := http.NewServeMux()
+	registerRuntimeV1Handlers(rm, externalRuntimeV1Prefix, metrics, logging, tracing, authToken)
 
 	em := http.NewServeMux()
 	em.HandleFunc("GET /enclave/attestation", attestationHandler(nsm, hashes))
 	em.HandleFunc("GET /enclave", rootHandler(cfg))
 	em.HandleFunc("GET /enclave/config", configHandler(cfg))
-	// Registered path by path rather than as a "/v1/" subtree. A subtree pattern here
-	// claims the whole namespace, so an application serving its own versioned API under
-	// /v1 would have every one of those routes answered by sm — which does not know
-	// them — instead of reaching revProxy below.
-	for _, path := range runtimeV1Paths {
-		em.Handle(path, corsWildcard(sm))
-	}
-
-	// ConfigureEnclaveInfoHandler registers GET /v1/enclave-info later. The subtree
-	// pattern used to answer its preflight; register that explicitly so the CORS
-	// behaviour is unchanged.
-	em.Handle("OPTIONS /v1/enclave-info", corsWildcard(http.NotFoundHandler()))
+	// Keep the public runtime API beneath /enclave/v1 so the application owns every
+	// other external path, including /v1.
+	em.Handle(externalRuntimeV1Prefix, corsWildcard(rm))
 
 	em.Handle("/health", sm)
 	em.Handle("/", revProxy)
@@ -156,12 +136,29 @@ func SetupHttpServers(
 		ext:     ext,
 		int:     int,
 		sm:      sm,
+		rm:      rm,
 		em:      em,
 		im:      im,
 		rt:      rt,
 		signer:  signer,
 		metrics: metrics,
 	}
+}
+
+func registerRuntimeV1Handlers(
+	mux *http.ServeMux,
+	prefix string,
+	metrics *Metrics,
+	logging *Logging,
+	tracing *Tracing,
+	authToken string,
+) {
+	mux.HandleFunc("POST "+prefix+"metrics", withTokenAuth(authToken, HandleMetricPost(metrics)))
+	mux.HandleFunc("GET "+prefix+"metrics", HandleMetricGet(metrics))
+	mux.HandleFunc("POST "+prefix+"logs", withTokenAuth(authToken, HandleLogsPost(logging)))
+	mux.HandleFunc("GET "+prefix+"logs", handleLogsGet(logging))
+	mux.HandleFunc("POST "+prefix+"traces", withTokenAuth(authToken, HandleTracingPost(tracing)))
+	mux.HandleFunc("GET "+prefix+"traces", HandleTracingGet(tracing))
 }
 
 func (s *servers) Start(ctx context.Context, cfg Config) error {
@@ -202,7 +199,7 @@ func (s *servers) Start(ctx context.Context, cfg Config) error {
 	return nil
 }
 
-// RuntimeInfo is the JSON body returned by GET /v1/enclave-info.
+// RuntimeInfo is the JSON body returned by GET /enclave/v1/info.
 type RuntimeInfo struct {
 	Version                  string           `json:"version"`
 	PreviousPCR0             string           `json:"previous_pcr0"`
@@ -220,7 +217,7 @@ func (s *servers) ConfigureEnclaveInfoHandler(
 	migrator Migrator,
 	ssm SSM,
 ) error {
-	s.em.HandleFunc("GET /v1/enclave-info", func(w http.ResponseWriter, r *http.Request) {
+	s.rm.HandleFunc("GET /enclave/v1/info", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 
 		migrationStatus, err := migrator.MigrationStatus(r.Context())
@@ -557,7 +554,7 @@ func upstreamTransport(mode string) http.RoundTripper {
 	}
 }
 
-// corsWildcard adds permissive CORS to /v1/* admin endpoints; app CORS stays upstream.
+// corsWildcard adds permissive CORS to external runtime API endpoints.
 func corsWildcard(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		h := w.Header()

--- a/runtime/servers.go
+++ b/runtime/servers.go
@@ -16,7 +16,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httputil"
-	"net/url"
 	"strings"
 	"time"
 
@@ -26,12 +25,12 @@ import (
 )
 
 const (
-	indexPage                 = "This host runs inside an AWS Nitro Enclave.\n"
 	nonceNumDigits            = 40 // 20-byte nonce, hex-encoded
 	migrationControlPort      = 8003
 	migrationRequestPath      = "/request-migration"
 	migrationFinalisationPath = "/finalise-migration"
-	externalRuntimeV1Prefix   = "/enclave/v1/"
+	enclavePrefix             = "/enclave/"
+	externalRuntimeV1Prefix   = enclavePrefix + "v1/"
 )
 
 var (
@@ -98,14 +97,10 @@ func SetupHttpServers(
 
 	rm := http.NewServeMux()
 	registerRuntimeV1Handlers(rm, externalRuntimeV1Prefix, metrics, logging, tracing, authToken)
+	rm.HandleFunc("GET /enclave/attestation", attestationHandler(nsm, hashes))
 
 	em := http.NewServeMux()
-	em.HandleFunc("GET /enclave/attestation", attestationHandler(nsm, hashes))
-	em.HandleFunc("GET /enclave", rootHandler(cfg))
-	em.HandleFunc("GET /enclave/config", configHandler(cfg))
-	// Keep the public runtime API beneath /enclave/v1 so the application owns every
-	// other external path, including /v1.
-	em.Handle(externalRuntimeV1Prefix, corsWildcard(rm))
+	em.Handle(enclavePrefix, corsWildcard(rm))
 
 	em.Handle("/health", sm)
 	em.Handle("/", revProxy)
@@ -121,10 +116,6 @@ func SetupHttpServers(
 			MinVersion:     tls.VersionTLS12,
 			NextProtos:     []string{"h2", "http/1.1", "acme-tls/1"},
 		},
-	}
-
-	if cfg.DisableKeepAlives {
-		ext.SetKeepAlivesEnabled(false)
 	}
 
 	int := &http.Server{
@@ -440,26 +431,6 @@ func certCallback(rt RuntimeState) TLSCertCallback {
 			return nil, nil
 		}
 		return getCert(hello)
-	}
-}
-
-func formatIndexPage(appURL *url.URL) string {
-	page := indexPage
-	if appURL != nil {
-		page += fmt.Sprintf("\nIt runs the following code: %s\n", appURL.String())
-	}
-	return page
-}
-
-func rootHandler(cfg Config) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintln(w, formatIndexPage(cfg.AppURL))
-	}
-}
-
-func configHandler(cfg Config) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		_, _ = fmt.Fprintln(w, cfg)
 	}
 }
 

--- a/runtime/servers.go
+++ b/runtime/servers.go
@@ -60,6 +60,17 @@ type servers struct {
 	metrics *Metrics
 }
 
+// runtimeV1Paths are the runtime's own endpoints beneath /v1. Everything else under
+// /v1 belongs to the application and is proxied to it.
+var runtimeV1Paths = []string{
+	"/v1/metrics",
+	"/v1/enclave-metrics",
+	"/v1/logs",
+	"/v1/enclave-logs",
+	"/v1/traces",
+	"/v1/enclave-traces",
+}
+
 func SetupHttpServers(
 	rt RuntimeState,
 	cfg Config,
@@ -103,7 +114,19 @@ func SetupHttpServers(
 	em.HandleFunc("GET /enclave/attestation", attestationHandler(nsm, hashes))
 	em.HandleFunc("GET /enclave", rootHandler(cfg))
 	em.HandleFunc("GET /enclave/config", configHandler(cfg))
-	em.Handle("/v1/", corsWildcard(sm))
+	// Registered path by path rather than as a "/v1/" subtree. A subtree pattern here
+	// claims the whole namespace, so an application serving its own versioned API under
+	// /v1 would have every one of those routes answered by sm — which does not know
+	// them — instead of reaching revProxy below.
+	for _, path := range runtimeV1Paths {
+		em.Handle(path, corsWildcard(sm))
+	}
+
+	// ConfigureEnclaveInfoHandler registers GET /v1/enclave-info later. The subtree
+	// pattern used to answer its preflight; register that explicitly so the CORS
+	// behaviour is unchanged.
+	em.Handle("OPTIONS /v1/enclave-info", corsWildcard(http.NotFoundHandler()))
+
 	em.Handle("/health", sm)
 	em.Handle("/", revProxy)
 

--- a/runtime/servers_test.go
+++ b/runtime/servers_test.go
@@ -242,7 +242,7 @@ func TestCorsWildcard(t *testing.T) {
 		}))
 
 		rr := httptest.NewRecorder()
-		h.ServeHTTP(rr, httptest.NewRequest(http.MethodOptions, "/v1/enclave-info", nil))
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodOptions, "/enclave/v1/info", nil))
 
 		if rr.Code != http.StatusNoContent {
 			t.Fatalf("status: got %d, want %d", rr.Code, http.StatusNoContent)
@@ -259,7 +259,7 @@ func TestCorsWildcard(t *testing.T) {
 		}))
 
 		rr := httptest.NewRecorder()
-		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/enclave-info", nil))
+		h.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/enclave/v1/info", nil))
 
 		if rr.Code != http.StatusCreated {
 			t.Fatalf("status: got %d, want %d", rr.Code, http.StatusCreated)
@@ -486,7 +486,7 @@ func TestMigrationControlHandlerExposesOnlyControlRoutes(t *testing.T) {
 	}{
 		{method: http.MethodGet, path: migrationRequestPath, code: http.StatusMethodNotAllowed},
 		{method: http.MethodGet, path: migrationFinalisationPath, code: http.StatusMethodNotAllowed},
-		{method: http.MethodGet, path: "/v1/enclave-info", code: http.StatusNotFound},
+		{method: http.MethodGet, path: "/enclave/v1/info", code: http.StatusNotFound},
 		{method: http.MethodGet, path: "/health", code: http.StatusNotFound},
 		{method: http.MethodPost, path: "/unknown", code: http.StatusNotFound},
 	} {
@@ -541,7 +541,7 @@ func TestConfigureEnclaveInfoHandler(t *testing.T) {
 	require.NoError(t, err)
 	rt := newRuntimeState()
 	metrics := NewMetrics()
-	s := &servers{em: http.NewServeMux(), rt: rt, signer: signer, metrics: metrics}
+	s := &servers{rm: http.NewServeMux(), rt: rt, signer: signer, metrics: metrics}
 	nsm := &nsmW{nsm: &fakeNSM{session: newStatefulNSMSession(t, map[uint][]byte{
 		0: bytes.Repeat([]byte{0xab}, 48),
 	})}}
@@ -554,7 +554,7 @@ func TestConfigureEnclaveInfoHandler(t *testing.T) {
 	require.NoError(t, err)
 
 	rr := httptest.NewRecorder()
-	s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/enclave-info", nil))
+	s.rm.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/enclave/v1/info", nil))
 
 	if rr.Code != http.StatusOK {
 		t.Fatalf("status: got %d, want %d", rr.Code, http.StatusOK)
@@ -578,12 +578,12 @@ func TestConfigureEnclaveInfoHandler(t *testing.T) {
 
 func TestConfigureEnclaveInfoHandlerFailsClosedOnStatusError(t *testing.T) {
 	statusErr := fmt.Errorf("S3 unavailable: %w", errMigrationIntentStoreUnavailable)
-	s := &servers{em: http.NewServeMux()}
+	s := &servers{rm: http.NewServeMux()}
 	migrator := &migrationControlMigrator{statusErr: statusErr}
 	require.NoError(t, s.ConfigureEnclaveInfoHandler(context.Background(), migrator, nil))
 
 	rr := httptest.NewRecorder()
-	s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/v1/enclave-info", nil))
+	s.rm.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/enclave/v1/info", nil))
 
 	require.Equal(t, http.StatusServiceUnavailable, rr.Code)
 	require.Contains(t, rr.Body.String(), statusErr.Error())
@@ -607,10 +607,7 @@ func assertCORSHeaders(t *testing.T, h http.Header) {
 	}
 }
 
-// A "/v1/" subtree pattern on the external mux claims the whole namespace, so an
-// application serving its own versioned API under /v1 has every one of those routes
-// answered by the runtime's 404 instead of reaching the reverse proxy.
-func TestExternalMuxLeavesApplicationV1RoutesToTheProxy(t *testing.T) {
+func TestExternalMuxSeparatesRuntimeAndApplicationRoutes(t *testing.T) {
 	var proxied []string
 	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		proxied = append(proxied, r.URL.Path)
@@ -636,31 +633,67 @@ func TestExternalMuxLeavesApplicationV1RoutesToTheProxy(t *testing.T) {
 		NewAttestationHashes(),
 		"token",
 	).(*servers)
+	require.NoError(t, s.ConfigureEnclaveInfoHandler(context.Background(), &migrationControlMigrator{
+		previous: &PreviousPCR0Info{},
+		status:   &MigrationStatus{},
+	}, nil))
 
 	t.Run("application routes reach the proxy", func(t *testing.T) {
-		for _, path := range []string{"/v1/info", "/v1/tx", "/v1/anything"} {
+		for _, route := range []struct {
+			method string
+			path   string
+		}{
+			{http.MethodGet, "/v1/info"},
+			{http.MethodPost, "/v1/metrics"},
+			{http.MethodPost, "/v1/logs"},
+			{http.MethodPost, "/v1/traces"},
+			{http.MethodGet, "/anything"},
+		} {
 			rr := httptest.NewRecorder()
-			s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
-			require.Equal(t, http.StatusOK, rr.Code, path)
-			require.Contains(t, proxied, path)
+			s.em.ServeHTTP(rr, httptest.NewRequest(route.method, route.path, nil))
+			require.Equal(t, http.StatusOK, rr.Code, "%s %s", route.method, route.path)
+			require.Contains(t, proxied, route.path)
 		}
 	})
 
-	t.Run("runtime routes are still claimed", func(t *testing.T) {
-		for _, path := range runtimeV1Paths {
+	t.Run("runtime routes are handled by the runtime", func(t *testing.T) {
+		for _, route := range []struct {
+			method string
+			path   string
+			status int
+		}{
+			{http.MethodGet, "/enclave/v1/info", http.StatusOK},
+			{http.MethodGet, "/enclave/v1/metrics", http.StatusOK},
+			{http.MethodGet, "/enclave/v1/logs", http.StatusOK},
+			{http.MethodGet, "/enclave/v1/traces", http.StatusOK},
+			{http.MethodPost, "/enclave/v1/metrics", http.StatusUnauthorized},
+			{http.MethodPost, "/enclave/v1/logs", http.StatusUnauthorized},
+			{http.MethodPost, "/enclave/v1/traces", http.StatusUnauthorized},
+		} {
 			rr := httptest.NewRecorder()
-			s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
-			require.NotContains(t, proxied, path)
+			s.em.ServeHTTP(rr, httptest.NewRequest(route.method, route.path, nil))
+			require.Equal(t, route.status, rr.Code, "%s %s", route.method, route.path)
+			require.NotContains(t, proxied, route.path)
+			assertCORSHeaders(t, rr.Header())
 		}
 	})
 
-	t.Run("preflight still answered for runtime routes", func(t *testing.T) {
-		paths := append(append([]string{}, runtimeV1Paths...), "/v1/enclave-info")
-		for _, path := range paths {
+	t.Run("runtime namespace handles preflight and rejects unknown routes", func(t *testing.T) {
+		for _, path := range []string{
+			"/enclave/v1/info",
+			"/enclave/v1/metrics",
+			"/enclave/v1/logs",
+			"/enclave/v1/traces",
+		} {
 			rr := httptest.NewRecorder()
 			s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodOptions, path, nil))
 			require.Equal(t, http.StatusNoContent, rr.Code, path)
-			require.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"), path)
+			assertCORSHeaders(t, rr.Header())
 		}
+
+		rr := httptest.NewRecorder()
+		s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/enclave/v1/unknown", nil))
+		require.Equal(t, http.StatusNotFound, rr.Code)
+		require.NotContains(t, proxied, "/enclave/v1/unknown")
 	})
 }

--- a/runtime/servers_test.go
+++ b/runtime/servers_test.go
@@ -633,10 +633,14 @@ func TestExternalMuxSeparatesRuntimeAndApplicationRoutes(t *testing.T) {
 		NewAttestationHashes(),
 		"token",
 	).(*servers)
-	require.NoError(t, s.ConfigureEnclaveInfoHandler(context.Background(), &migrationControlMigrator{
-		previous: &PreviousPCR0Info{},
-		status:   &MigrationStatus{},
-	}, nil))
+	require.NoError(t, s.ConfigureEnclaveInfoHandler(
+		context.Background(),
+		&migrationControlMigrator{
+			previous: &PreviousPCR0Info{},
+			status:   &MigrationStatus{},
+		},
+		nil,
+	))
 
 	t.Run("application routes reach the proxy", func(t *testing.T) {
 		for _, route := range []struct {
@@ -709,7 +713,7 @@ func TestExternalMuxSeparatesRuntimeAndApplicationRoutes(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 		s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/enclave", nil))
-		
+
 		require.Contains(t, []int{
 			http.StatusMovedPermanently,
 			http.StatusTemporaryRedirect,

--- a/runtime/servers_test.go
+++ b/runtime/servers_test.go
@@ -709,7 +709,11 @@ func TestExternalMuxSeparatesRuntimeAndApplicationRoutes(t *testing.T) {
 
 		rr := httptest.NewRecorder()
 		s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/enclave", nil))
-		require.Equal(t, http.StatusMovedPermanently, rr.Code)
+		
+		require.Contains(t, []int{
+			http.StatusMovedPermanently,
+			http.StatusTemporaryRedirect,
+		}, rr.Code)
 		require.Equal(t, "/enclave/", rr.Header().Get("Location"))
 		require.NotContains(t, proxied, "/enclave")
 	})

--- a/runtime/servers_test.go
+++ b/runtime/servers_test.go
@@ -644,9 +644,11 @@ func TestExternalMuxSeparatesRuntimeAndApplicationRoutes(t *testing.T) {
 			path   string
 		}{
 			{http.MethodGet, "/v1/info"},
+			{http.MethodOptions, "/v1/orders"},
 			{http.MethodPost, "/v1/metrics"},
 			{http.MethodPost, "/v1/logs"},
 			{http.MethodPost, "/v1/traces"},
+			{http.MethodGet, "/enclavex/v1"},
 			{http.MethodGet, "/anything"},
 		} {
 			rr := httptest.NewRecorder()
@@ -691,9 +693,24 @@ func TestExternalMuxSeparatesRuntimeAndApplicationRoutes(t *testing.T) {
 			assertCORSHeaders(t, rr.Header())
 		}
 
+		for _, route := range []struct {
+			method string
+			path   string
+		}{
+			{http.MethodGet, "/enclave/unknown"},
+			{http.MethodGet, "/enclave/v1ish"},
+			{http.MethodGet, "/enclave/v1/unknown"},
+		} {
+			rr := httptest.NewRecorder()
+			s.em.ServeHTTP(rr, httptest.NewRequest(route.method, route.path, nil))
+			require.Equal(t, http.StatusNotFound, rr.Code, "%s %s", route.method, route.path)
+			require.NotContains(t, proxied, route.path)
+		}
+
 		rr := httptest.NewRecorder()
-		s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/enclave/v1/unknown", nil))
-		require.Equal(t, http.StatusNotFound, rr.Code)
-		require.NotContains(t, proxied, "/enclave/v1/unknown")
+		s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodPost, "/enclave", nil))
+		require.Equal(t, http.StatusMovedPermanently, rr.Code)
+		require.Equal(t, "/enclave/", rr.Header().Get("Location"))
+		require.NotContains(t, proxied, "/enclave")
 	})
 }

--- a/runtime/servers_test.go
+++ b/runtime/servers_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -604,4 +605,62 @@ func assertCORSHeaders(t *testing.T, h http.Header) {
 	if h.Get("Access-Control-Max-Age") != "600" {
 		t.Fatalf("Access-Control-Max-Age: got %q, want 600", h.Get("Access-Control-Max-Age"))
 	}
+}
+
+// A "/v1/" subtree pattern on the external mux claims the whole namespace, so an
+// application serving its own versioned API under /v1 has every one of those routes
+// answered by the runtime's 404 instead of reaching the reverse proxy.
+func TestExternalMuxLeavesApplicationV1RoutesToTheProxy(t *testing.T) {
+	var proxied []string
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		proxied = append(proxied, r.URL.Path)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer app.Close()
+
+	appURL, err := url.Parse(app.URL)
+	require.NoError(t, err)
+
+	metrics := NewMetrics()
+	signer, err := NewAttestedSigner()
+	require.NoError(t, err)
+
+	s := SetupHttpServers(
+		newRuntimeState(),
+		Config{AppWebSrv: appURL},
+		&nsmW{},
+		metrics,
+		NewLogging(metrics, nil),
+		NewTracing(nil),
+		signer,
+		NewAttestationHashes(),
+		"token",
+	).(*servers)
+
+	t.Run("application routes reach the proxy", func(t *testing.T) {
+		for _, path := range []string{"/v1/info", "/v1/tx", "/v1/anything"} {
+			rr := httptest.NewRecorder()
+			s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+			require.Equal(t, http.StatusOK, rr.Code, path)
+			require.Contains(t, proxied, path)
+		}
+	})
+
+	t.Run("runtime routes are still claimed", func(t *testing.T) {
+		for _, path := range runtimeV1Paths {
+			rr := httptest.NewRecorder()
+			s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+			require.NotContains(t, proxied, path)
+		}
+	})
+
+	t.Run("preflight still answered for runtime routes", func(t *testing.T) {
+		paths := append(append([]string{}, runtimeV1Paths...), "/v1/enclave-info")
+		for _, path := range paths {
+			rr := httptest.NewRecorder()
+			s.em.ServeHTTP(rr, httptest.NewRequest(http.MethodOptions, path, nil))
+			require.Equal(t, http.StatusNoContent, rr.Code, path)
+			require.Equal(t, "*", rr.Header().Get("Access-Control-Allow-Origin"), path)
+		}
+	})
 }

--- a/runtime/tracing.go
+++ b/runtime/tracing.go
@@ -246,7 +246,7 @@ func HandleTracingPost(t *Tracing) http.HandlerFunc {
 }
 
 // HandleTracingGet returns buffered spans.
-// GET /v1/enclave-traces?since=RFC3339&limit=100&service=app|supervisor
+// GET /enclave/v1/traces externally; GET /v1/traces on the internal listener.
 func HandleTracingGet(t *Tracing) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		var since time.Time

--- a/runtime/tracing_test.go
+++ b/runtime/tracing_test.go
@@ -182,7 +182,7 @@ func TestTracingHandlers(t *testing.T) {
 			tracing,
 		)(
 			w,
-			httptest.NewRequest(http.MethodGet, "/v1/enclave-traces?service=app&limit=1", nil),
+			httptest.NewRequest(http.MethodGet, "/v1/traces?service=app&limit=1", nil),
 		)
 
 		require.Equal(t, http.StatusOK, w.Code)
@@ -201,7 +201,7 @@ func TestTracingHandlers(t *testing.T) {
 		tracing := &Tracing{buf: newSpanBuffer(1)}
 		w := httptest.NewRecorder()
 
-		HandleTracingGet(tracing)(w, httptest.NewRequest(http.MethodGet, "/v1/enclave-traces", nil))
+		HandleTracingGet(tracing)(w, httptest.NewRequest(http.MethodGet, "/v1/traces", nil))
 
 		require.Equal(t, http.StatusOK, w.Code)
 		require.JSONEq(t, `[]`, w.Body.String())


### PR DESCRIPTION
Fixes #164.

`em.Handle("/v1/", corsWildcard(sm))` is a Go `ServeMux` **subtree** pattern, so every
`/v1/*` request was routed to `sm` whether or not `sm` knew the path. An application
serving its own versioned API under `/v1` had all of it answered by the runtime's 404,
and never reached `revProxy`.

## Observed

Against a real deployment, the emulator's entire REST surface was unreachable through the
enclave:

```
GET  /v1/info           404
POST /v1/tx             404
POST /v1/intent         404
POST /v1/finalization   404
POST /v1/onchain-tx     404
```

Its gRPC worked, because that path is `/emulator.v1.EmulatorService/...`, and `/healthz`
worked because it sits outside `/v1`. Only the REST gateway was dead — which is what made
it easy to miss.

`/v1` is a conventional API prefix, so this affects any application with a versioned REST
API, and it is not configurable around: the prefix is hardcoded and no environment
variable touches routing.

## Change

Register the runtime's six `/v1` endpoints individually. They were already enumerated on
`sm`, so the subtree pattern was not buying anything.

Two details preserved deliberately:

- **`/v1/enclave-info` preflight.** It is registered later by
  `ConfigureEnclaveInfoHandler` as `GET`-only, and relied on the subtree to answer its
  `OPTIONS`. That route is now explicit, so CORS behaviour is unchanged.
- **The internal mux keeps its subtree.** `im` has no reverse proxy, so there is nothing
  for it to shadow.

Paths are registered without a method, as the subtree was, so `OPTIONS` still reaches
`corsWildcard` and a method mismatch still yields 405 from `sm` rather than falling
through to the application.

## Test

`TestExternalMuxLeavesApplicationV1RoutesToTheProxy` stands up a real `SetupHttpServers`
against a recording backend and asserts three things: application routes under `/v1`
reach the proxy, the runtime's own routes do not, and preflight is still answered for the
runtime's routes including `/v1/enclave-info`.

Confirmed it fails on the old routing with exactly the reported symptom:

```
--- FAIL: TestExternalMuxLeavesApplicationV1RoutesToTheProxy/application_routes_reach_the_proxy
        expected: 200
        actual  : 404
        Messages: /v1/info
```

`go test ./...`, `go vet ./...` and `gofmt -l .` are clean on the full runtime module.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ArkLabsHQ/codesmith/enclave/pr/165"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790418593&installation_model_id=433183&pr_number=165&repository=ArkLabsHQ%2Fenclave&return_to=https%3A%2F%2Fgithub.com%2FArkLabsHQ%2Fenclave%2Fpull%2F165&signature=0ec7f6f409ac97fd73adbf8d30fddcde7de433a798b89228a1a26232596b56f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->